### PR TITLE
docs: expand README and add CLAUDE.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ Desktop.ini
 
 # Git worktrees
 .worktrees/
+
+# Local brainstorming / design scratch — not part of the public repo
+docs/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,195 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code when working in this repository.
+
+## Project overview
+
+`claude-docker-sandbox` ships a single bash script — `cc` — that wraps
+Claude Code invocations in a [Docker Sandbox](https://docs.docker.com/ai/sandboxes/)
+microVM, so `--dangerously-skip-permissions` can be used with a bounded blast
+radius instead of an unbounded one. See [`README.md`](README.md) for
+user-facing documentation.
+
+The implementation is intentionally small: one shell script, one config file,
+one README. Resist the urge to grow it into a framework.
+
+## Repository layout
+
+```
+.
+├── bin/cc                  the wrapper script (not yet written)
+├── README.md               user-facing documentation
+├── CLAUDE.md               this file
+├── LICENSE                 MIT
+└── .gitignore              ignores .worktrees/ and local docs/
+```
+
+**`docs/` is gitignored.** It's reserved for local brainstorming and design
+scratch files — the design spec that drove the initial implementation lives
+there on the author's machine and is deliberately *not* committed to the
+public repo. If you need to reference design history, look for it locally; do
+not try to reconstruct it from git history.
+
+## How to think about the script
+
+`cc` runs in three phases on every invocation. When modifying it, keep these
+phases distinct — do not interleave parsing with planning or planning with
+execution.
+
+1. **Parse.** Walk `$@` once. Any arg starting with `--cc-` is a wrapper flag
+   and gets consumed; everything else goes into a `CLAUDE_ARGS` array to be
+   forwarded verbatim to `claude` inside the sandbox.
+2. **Plan.** Run preflight checks. Read `~/.config/cc/mounts.conf` (create it
+   from defaults if missing). Apply `--cc-mount` additions and `--cc-no-mount`
+   removals. Compute a deterministic sandbox name from cwd. Build the final
+   `sbx run claude` argv.
+3. **Exec.** Run `sbx run` foregrounded (not `exec`'d), forwarding signals.
+   If sbx exits non-zero with a known mount-overlap error, retry once with the
+   sibling-expansion fallback. Otherwise propagate sbx's exit code.
+
+The `--cc-dry-run`, `--cc-doctor`, and `--cc-no-sandbox` flags short-circuit
+the exec phase in different ways; they still run parse and the relevant parts
+of plan.
+
+## Code style
+
+### Bash
+
+- Shebang: `#!/usr/bin/env bash`
+- `set -euo pipefail` at the top
+- Quote all variable expansions: `"$var"`, not `$var`
+- Prefer `[[ … ]]` over `[ … ]` for conditionals
+- Functions over repeated inline blocks
+- Functions under ~50 lines, ideally under 20
+- Nesting no more than 3 levels deep
+- Descriptive names — no single-letter variables except loop counters
+
+### General
+
+- Comments explain *why*, not *what*. If the code needs a comment to be
+  readable, simplify the code.
+- Delete dead code; don't comment it out
+- KISS — the simplest solution that works. Abstractions only after the third
+  duplication, never preemptively.
+- YAGNI — don't add configuration for values that don't change. Don't add
+  flags that solve hypothetical problems.
+
+### What this script deliberately is not
+
+- It is **not a config manager**. Only mount paths are configurable; every
+  other parameter (Docker start timeout, sandbox name hash format, preflight
+  check list) is hardcoded. If something new needs to change, think twice
+  before moving it to config.
+- It is **not a container orchestrator**. It forwards to `sbx run` and lets
+  sbx own sandbox lifecycle.
+- It is **not a Claude Code replacement**. It wraps the `claude` binary
+  without trying to understand its flags, and `claude` is always available
+  unwrapped as an escape hatch.
+
+## Git workflow
+
+### Always use worktrees
+
+Never work directly in the main checkout. Always create a worktree for each
+unit of work, even for one-file changes:
+
+```bash
+git checkout main && git pull origin main
+git worktree add .worktrees/<type>-<short-description> -b <type>/<short-description>
+cd .worktrees/<type>-<short-description>
+```
+
+Branch prefixes: `feat/`, `fix/`, `chore/`, `docs/`, `refactor/`, `test/`,
+`perf/`.
+
+### Branch check before every change
+
+```bash
+git fetch origin
+git merge-base --is-ancestor origin/main HEAD || git pull origin main
+```
+
+### Never push to main, never force push
+
+- Never push directly to `main`. Always open a PR via `gh pr create`.
+- Never force push. If a branch is behind `main`, merge `main` into it.
+
+### Commit messages
+
+Conventional format:
+
+- `feat: add user authentication`
+- `fix: resolve null pointer in parser`
+- `chore: update dependencies`
+- `docs: add API documentation`
+- `refactor: simplify error handling`
+
+## Testing
+
+There is **no automated test suite.** This is a bash wrapper around a CLI on
+a specific developer machine; the validation model is a manual checklist.
+
+When changing `bin/cc`, walk through the full validation matrix before opening
+a PR:
+
+1. **Preflight matrix.** Run `cc --cc-doctor` with each dependency
+   intentionally broken, confirm the right FAIL lines appear with actionable
+   remedies. Restore state.
+2. **Core invocation matrix.** From a real project under `~/workspace`,
+   exercise `cc`, `cc -c`, `cc --cc-name experiment-1`, `cc --cc-no-sandbox`,
+   `cc --cc-dry-run`, `cc --cc-ls`, `cc --cc-rm`.
+3. **Mount override matrix.** Confirm `--cc-mount` additions and
+   `--cc-no-mount` removals appear correctly in `--cc-dry-run` output.
+4. **Worktree sanity.** Run `cc` from a `.worktrees/feat-foo` directory under
+   another repo and confirm the primary mount is the worktree path, not the
+   main checkout.
+5. **Failure spot checks.** Quit Docker Desktop mid-session, Ctrl-C during the
+   30 s Docker wait, run from a directory outside `~/workspace`.
+
+Shell lint:
+
+```bash
+shellcheck bin/cc
+shfmt -d bin/cc
+```
+
+Install if missing: `brew install shellcheck shfmt`.
+
+## Three first-run unknowns
+
+The design has three places where real sbx behavior needs to be verified on
+first run rather than assumed:
+
+1. **sbx arg-passing syntax.** The plausible guess is
+   `sbx run claude <mounts> -- <claude-args>`. On first run, if `cc -c`
+   doesn't resume a session or `claude` complains about `-c`, inspect
+   `sbx run claude --help` and adjust.
+2. **Nested mount handling.** `$PWD` (RW) sits inside `~/workspace` (RO).
+   Linux bind-mount semantics say the inner mount should shadow the outer on
+   its subpath, but sbx's microVM may or may not pass that through. If
+   rejected, the script retries once with a sibling-expansion fallback (see
+   `bin/cc` plan phase).
+3. **`~/.claude` cross-visibility.** The session-persistence story hinges on
+   `~/.claude` being a live bind mount and cwd resolving to the same absolute
+   path inside the sandbox. Verify by starting a session with host `claude`,
+   exiting, running `cc -c`, and confirming the same session resumes.
+
+If any of these break in a way that can't be patched with a one-line fix,
+open an issue documenting what sbx actually does.
+
+## Scope discipline
+
+This repo intentionally does one thing. **Do not** add:
+
+- A custom sandbox Dockerfile. sbx's default agent image is sufficient.
+- A Python / Node / Go rewrite. Bash is the right tool for a < 300 line
+  wrapper around another CLI.
+- Cross-host state sync, a daemon, a plugin system, or a TUI. They belong in
+  a different project.
+- Automated test harnesses. Manual validation is adequate for a wrapper
+  script and the overhead of setting up test infrastructure around `sbx`
+  would dwarf the script itself.
+
+If a change you're considering doesn't fit in a `feat:` or `fix:` commit
+against `bin/cc`, `README.md`, `CLAUDE.md`, or `.gitignore`, it probably
+doesn't belong in this repo.

--- a/README.md
+++ b/README.md
@@ -1,30 +1,273 @@
 # claude-docker-sandbox
 
-A small wrapper (`cc`) that runs Claude Code inside a Docker Sandbox
-(`sbx`) microVM, so `--dangerously-skip-permissions` becomes a bounded risk
-instead of an unbounded one.
+`cc` — a small bash wrapper that runs [Claude Code](https://claude.com/claude-code)
+inside a [Docker Sandbox](https://docs.docker.com/ai/sandboxes/) microVM, so
+`--dangerously-skip-permissions` becomes a bounded risk instead of an
+unbounded one.
 
-## Status
+> **Status:** Design approved, implementation in progress. The `cc` script
+> itself has not been written yet. See [Roadmap](#roadmap) for what's coming.
 
-Design phase. See [`docs/specs/`](docs/specs/) for the design spec.
-The implementation script has not been written yet.
+## What this solves
 
-## Overview
+Running `claude --dangerously-skip-permissions` on a trusted developer machine
+is a calculated but unbounded risk: an agent with unsupervised shell access can
+touch anything the user can touch. Docker Sandboxes give each agent its own
+microVM with its own filesystem, Docker daemon, and network, so a runaway
+agent is contained to what you explicitly mount in.
 
-`cc` is a thin bash wrapper around [Docker Sandboxes](https://docs.docker.com/ai/sandboxes/)
-that:
+`cc` is a thin shell wrapper around Docker's `sbx` CLI that:
 
-- Mounts the launch directory read-write into a microVM
-- Mounts a configurable allow-list of host paths read-only for context
-  (e.g. `~/workspace`, `~/Desktop`, `~/Downloads`)
-- Shares `~/.claude` read-write so sessions persist across host ↔ sandbox
-- Forwards all non-`--cc-*` flags to `claude` inside the sandbox
+- Mounts your current working directory **read-write** into the sandbox
+- Mounts a configurable allow-list of host paths **read-only** for context
+  (e.g. `~/workspace` for cross-project references, `~/Desktop` / `~/Downloads`
+  for ad-hoc file sharing)
+- Shares `~/.claude` **read-write** so your Claude Code session history persists
+  across runs *and* is visible from both host `claude` and sandboxed `cc`
+- Shares `~/.aws`, `~/.config/gh`, and `~/.ssh` **read-only** so credentials
+  work without letting the agent overwrite them
+- Forwards every non-`--cc-*` flag to `claude` inside the sandbox
 - Runs preflight checks (sbx installed, Docker running, sbx authenticated,
-  `~/.claude` writable)
-- Auto-starts Docker Desktop if it isn't running
+  `~/.claude` writable) and auto-starts Docker Desktop if it isn't already up
 
-More details will land here as the implementation comes together.
+## Prerequisites
+
+- **Docker Desktop** (macOS / Windows / Linux)
+- **sbx CLI**
+  ```console
+  # macOS
+  brew install docker/tap/sbx
+
+  # Windows
+  winget install -h Docker.sbx
+
+  # Linux (Ubuntu)
+  curl -fsSL https://get.docker.com | sudo REPO_ONLY=1 sh
+  sudo apt-get install docker-sbx
+  sudo usermod -aG kvm $USER
+  newgrp kvm
+  ```
+- One-time login:
+  ```console
+  sbx login
+  ```
+- **Claude Code** installed on the host (`cc` still needs a host binary for its
+  escape hatch; see [Escape hatch](#escape-hatch))
+
+## Install
+
+> Not yet available. Install instructions will land here once the `cc` script
+> ships. Planned form:
+>
+> ```console
+> curl -fsSL https://raw.githubusercontent.com/patclarke/claude-docker-sandbox/main/bin/cc -o ~/bin/cc
+> chmod +x ~/bin/cc
+> # make sure ~/bin is on PATH
+> cc --cc-doctor
+> ```
+
+## Usage
+
+### Day-to-day
+
+```bash
+cd ~/workspace/my-project
+caffeinate -dims cc --remote-control --chrome -c
+```
+
+`cc` treats anything that isn't a `--cc-*` flag as a pass-through argument
+for `claude` inside the sandbox. Your existing Claude Code muscle memory works
+unchanged.
+
+### Common invocations
+
+```bash
+# Fresh session in this directory
+cc
+
+# Resume the most recent session in this directory
+cc -c
+
+# Forward arbitrary Claude Code flags
+cc --remote-control --chrome -c
+
+# Two parallel sandboxes in the same directory
+cc --cc-name experiment-a -c
+cc --cc-name experiment-b -c
+
+# One-off: share a folder outside the default mount list
+cc --cc-mount ~/Projects/weird-experiment:ro -c
+
+# One-off: don't let the sandbox see ~/Downloads this session
+cc --cc-no-mount ~/Downloads
+
+# Escape hatch — run host claude directly, bypass sbx entirely
+cc --cc-no-sandbox -c
+# …or just run the real binary
+claude -c
+```
+
+### Flags
+
+`cc` reserves only flags with a `--cc-*` prefix. Everything else passes
+through to `claude` untouched.
+
+| Flag                      | Purpose                                                       |
+|---------------------------|---------------------------------------------------------------|
+| `--cc-name <label>`       | Named sandbox (for running parallel sessions in the same dir) |
+| `--cc-mount <path>[:ro]`  | Add an extra mount for this invocation (repeatable)           |
+| `--cc-no-mount <path>`    | Skip a config-file mount for this invocation (repeatable)    |
+| `--cc-no-sandbox`         | Escape hatch — exec host `claude` directly                    |
+| `--cc-rm [name]`          | Remove the sandbox for cwd (or the named one), with a prompt  |
+| `--cc-ls`                 | List active sandboxes                                         |
+| `--cc-dry-run`            | Print the resolved `sbx run` command for this cwd, don't exec |
+| `--cc-doctor`             | Run preflight checks and show the resolved mount list         |
+| `--cc-help`               | Usage                                                         |
+
+## Mount policy
+
+The mount plan is built on every invocation in this order:
+
+1. **Primary mount: `$PWD`** — read-write, always. Becomes sbx's main
+   workspace and the starting directory for the agent.
+2. **Config file** — `~/.config/cc/mounts.conf`, one mount per line.
+3. **`--cc-mount` flags** — appended.
+4. **`--cc-no-mount` flags** — removed.
+5. **Dedupe** — later / more specific entries win.
+
+### Default `~/.config/cc/mounts.conf`
+
+Written automatically the first time you run `cc`:
+
+```
+# Format:  <path>[:ro]
+# No suffix = read-write. ":ro" = read-only.
+# Non-existent paths are skipped silently at launch.
+
+# Cross-project reference (read-only view of sibling repos)
+~/workspace:ro
+
+# Ad-hoc file sharing from normal macOS locations
+~/Desktop:ro
+~/Downloads:ro
+
+# Host config surfaced into the sandbox
+~/.claude                 # RW — session persistence + plugins/skills
+~/.aws:ro                 # AWS credentials read-only
+~/.config/gh:ro           # gh CLI auth read-only
+~/.ssh:ro                 # git over ssh read-only
+```
+
+### What each mount is for
+
+| Path                 | Mode | Why                                                   |
+|----------------------|------|-------------------------------------------------------|
+| `$PWD` (launch dir)  | RW   | The actual work happens here                          |
+| `~/workspace`        | RO   | Cross-project context; writes only via launch dir     |
+| `~/Desktop`          | RO   | Share a file with the agent without moving it         |
+| `~/Downloads`        | RO   | Same, for downloaded artifacts                        |
+| `~/.claude`          | RW   | Session persistence; host ↔ sandbox visibility        |
+| `~/.aws`             | RO   | Credentials available to code running in the sandbox  |
+| `~/.config/gh`       | RO   | `gh` CLI auth                                         |
+| `~/.ssh`             | RO   | git over ssh                                          |
+
+### Customizing
+
+Permanent changes: edit `~/.config/cc/mounts.conf`. One line per mount,
+`#` for comments, `~` expansion supported, `:ro` suffix for read-only.
+Non-existent paths are skipped silently.
+
+```bash
+# Add a permanent mount
+echo '~/Notes:ro' >> ~/.config/cc/mounts.conf
+
+# Remove a permanent mount — just delete or comment out the line
+```
+
+One-off changes: use `--cc-mount` or `--cc-no-mount` on a single invocation.
+
+## Session persistence
+
+Because `~/.claude` is a **live bind mount** (not a copy), any session files
+written from inside the sandbox land in your real `~/.claude/projects/…`
+directory on the host. Inside the sandbox, `cwd` resolves to the same absolute
+host path (`sbx` preserves absolute paths), so `claude -c` finds the same
+sessions whether you're running it on the host or through `cc`.
+
+Three properties fall out of this:
+
+1. Conversations **survive** `sbx rm`, OS reboots, or swapping sandbox images
+2. A session started with host `claude` is resumable with `cc -c`, and vice
+   versa
+3. Your Claude Code plugins and skills (`~/.claude/plugins/`) are visible
+   inside the sandbox — plugin skills work identically in both environments
+
+## Security model
+
+**What the sandbox can see:** only the paths explicitly mounted. Anything else
+on your host filesystem is invisible.
+
+**What the sandbox can modify:** only the `$PWD` you launched from and
+`~/.claude`. Everything else in the default mount list is read-only, so a
+runaway agent cannot rewrite your credentials, overwrite sibling projects, or
+touch your Desktop files.
+
+**What isolates the sandbox from your host:** microVM (hypervisor-level)
+isolation via Docker Sandboxes. Each sandbox has its own Linux kernel,
+filesystem, Docker daemon, and network namespace. Outbound traffic routes
+through an HTTP/HTTPS proxy on your host for credential injection and network
+policy.
+
+**What `--dangerously-skip-permissions` buys you** inside this model: the
+ability to run unsupervised agents that install packages, run `git` commands,
+and execute shell tools without a per-command prompt, while the blast radius
+stays bounded by the mount list. It's still a calculated risk — read-only
+mounts are exfiltration surfaces, and anything in `$PWD` or `~/.claude` is
+writable — but you're now trading "anything on my Mac" for "anything in these
+specific directories."
+
+## Preflight checks
+
+`cc` runs the following on every invocation before planning or exec:
+
+1. `sbx` is installed (`command -v sbx`)
+2. Docker Desktop is running (`docker info`) — **auto-starts** with a 30 s
+   timeout if not
+3. `sbx` is authenticated (`sbx ls` probe)
+4. `~/.claude` is writable
+5. Optional mount paths exist (missing ones are WARN, not FAIL)
+6. Host `claude` binary exists (only when `--cc-no-sandbox` is in effect)
+
+Short-circuit: `--cc-no-sandbox` skips checks 1–5 entirely. The whole point of
+the escape hatch is "sbx/docker are broken, I need to work anyway."
+
+Run `cc --cc-doctor` anytime to see the full status without launching a
+sandbox.
+
+## Escape hatch
+
+If sbx, Docker Desktop, or `cc` itself ever breaks, **`claude` is always still
+on your PATH unmodified**. `cc` does not alias or shadow it. Two ways to bail:
+
+```bash
+# Run host claude through the cc wrapper (skips all sandbox logic)
+cc --cc-no-sandbox -c
+
+# Or just run the real binary directly
+claude -c
+```
+
+## Roadmap
+
+- [x] Design locked in
+- [x] Repo bootstrapped with README + CLAUDE.md
+- [ ] `bin/cc` script — parse, plan, preflight, exec phases
+- [ ] First-run verification of the three unknowns: sbx arg-passing syntax,
+      nested-mount handling, `~/.claude` cross-visibility
+- [ ] `cc --cc-doctor` output formatting
+- [ ] Manual validation matrix walked through
+- [ ] Install instructions + `brew` / `curl` one-liner
 
 ## License
 
-MIT — see [`LICENSE`](LICENSE).
+[MIT](LICENSE) — Copyright (c) 2026 Pat Clarke


### PR DESCRIPTION
## Summary
- Replaces the stub `README.md` with full user-facing documentation: what the project solves, prerequisites, usage, flag reference, mount policy, session persistence, security model, preflight checks, escape hatches, and roadmap
- Adds `CLAUDE.md` with project-specific guidance for Claude Code sessions working on this repository: the three execution phases of `cc`, bash style rules, git worktree workflow, manual validation model, and the three first-run unknowns
- Gitignores `docs/` so local brainstorming / design-scratch files stay off the public repo

## Why
The public repo should contain user-facing documentation and project guidance, not brainstorming artifacts. Design spec that drove this has been moved to a gitignored local-only `docs/specs/` directory on the author's machine.

## Test plan
- [ ] Render the README on GitHub and confirm formatting / tables / code blocks look right
- [ ] Render CLAUDE.md and confirm it's a reasonable onboarding doc for a future Claude Code session
- [ ] Confirm `docs/` is gitignored (run `git status` after creating a file under `docs/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)