### PR TITLE
feat: implement bin/cc wrapper script

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,18 +6,23 @@ This file provides guidance to Claude Code when working in this repository.
 
 `claude-docker-sandbox` ships a single bash script — `cc` — that wraps
 Claude Code invocations in a [Docker Sandbox](https://docs.docker.com/ai/sandboxes/)
-microVM, so `--dangerously-skip-permissions` can be used with a bounded blast
-radius instead of an unbounded one. See [`README.md`](README.md) for
-user-facing documentation.
+microVM, so unsupervised agents have a bounded blast radius instead of an
+unbounded one. See [`README.md`](README.md) for user-facing documentation.
 
 The implementation is intentionally small: one shell script, one config file,
 one README. Resist the urge to grow it into a framework.
+
+**Auth flow:** `cc` extracts the Claude Code token from the macOS Keychain
+(`security find-generic-password -s 'Claude Code-credentials'`) and injects it
+into the sandbox on every invocation via `sbx exec`. Claude inside the sandbox
+runs as user `agent` and looks for credentials at
+`/home/agent/.claude/.credentials.json`.
 
 ## Repository layout
 
 ```
 .
-├── bin/cc                  the wrapper script (not yet written)
+├── bin/cc                  the wrapper script
 ├── README.md               user-facing documentation
 ├── CLAUDE.md               this file
 ├── LICENSE                 MIT
@@ -41,15 +46,54 @@ execution.
    forwarded verbatim to `claude` inside the sandbox.
 2. **Plan.** Run preflight checks. Read `~/.config/cc/mounts.conf` (create it
    from defaults if missing). Apply `--cc-mount` additions and `--cc-no-mount`
-   removals. Compute a deterministic sandbox name from cwd. Build the final
-   `sbx run claude` argv.
-3. **Exec.** Run `sbx run` foregrounded (not `exec`'d), forwarding signals.
-   If sbx exits non-zero with a known mount-overlap error, retry once with the
-   sibling-expansion fallback. Otherwise propagate sbx's exit code.
+   removals. Strip ancestor mounts. Compute a deterministic sandbox name from
+   cwd. Build the final `sbx` argv.
+3. **Exec.** If the named sandbox doesn't exist, create it with
+   `sbx create claude <primary> <mounts>`. Then inject credentials via
+   `sbx exec`. Then create sharing symlinks via `sbx exec`. Finally attach
+   with `sbx run <name> -- <claude-args>`, foregrounded with signal forwarding.
+   Propagate sbx's exit code.
 
 The `--cc-dry-run`, `--cc-doctor`, and `--cc-no-sandbox` flags short-circuit
 the exec phase in different ways; they still run parse and the relevant parts
 of plan.
+
+## Key sbx behaviors (verified in live testing)
+
+These were the three first-run unknowns from the original design. All are now
+resolved:
+
+1. **Primary workspace path.** sbx remaps the primary workspace to
+   `/home/agent/workspace` inside the container. It does NOT preserve the
+   absolute host path for the primary mount. Additional mounts (e.g. `~/.aws`)
+   DO land at their absolute host paths inside the sandbox.
+
+2. **Nested mounts fail.** When cwd is inside `~/workspace` and both are
+   mounted, sbx's container-start hook tries to chown the cwd's parent
+   directory (inside the RO parent mount) and fails with "Read-only file
+   system". Fix: `strip_cwd_ancestors` removes any mount that is a strict
+   ancestor of `$PWD` before passing the list to sbx.
+
+3. **Auth.** Claude inside the sandbox runs as user `agent` with
+   `HOME=/home/agent`. It looks for credentials at
+   `/home/agent/.claude/.credentials.json`. A bind mount of `~/.claude` at its
+   absolute host path doesn't help because sbx has no env var flag to remap
+   `$HOME`. Fix: `inject_credentials` extracts the token from the macOS
+   Keychain non-interactively and writes it to the correct path via `sbx exec`.
+
+4. **sbx has no env var flag.** `sbx run --help` only supports `--branch`,
+   `--memory`, `--name`, `--template`. There is no way to pass env vars via
+   sbx. Credentials and other config must be injected via `sbx exec`.
+
+5. **Bypass mode is the default.** sbx's claude image has
+   `"defaultMode": "bypassPermissions"` pre-configured in
+   `/home/agent/.claude/settings.json`. Do not add any bypass flag as a
+   default in `cc`.
+
+6. **Create vs. attach.** Passing workspace paths to an existing sandbox errors
+   with "sandbox X already exists and can't be given new workspaces". The
+   correct flow: `sbx create claude <primary> <mounts>` once, then
+   `sbx run <name>` on every subsequent attach.
 
 ## Code style
 
@@ -80,7 +124,7 @@ of plan.
   other parameter (Docker start timeout, sandbox name hash format, preflight
   check list) is hardcoded. If something new needs to change, think twice
   before moving it to config.
-- It is **not a container orchestrator**. It forwards to `sbx run` and lets
+- It is **not a container orchestrator**. It forwards to `sbx` and lets
   sbx own sandbox lifecycle.
 - It is **not a Claude Code replacement**. It wraps the `claude` binary
   without trying to understand its flags, and `claude` is always available
@@ -155,28 +199,6 @@ shfmt -d bin/cc
 
 Install if missing: `brew install shellcheck shfmt`.
 
-## Three first-run unknowns
-
-The design has three places where real sbx behavior needs to be verified on
-first run rather than assumed:
-
-1. **sbx arg-passing syntax.** The plausible guess is
-   `sbx run claude <mounts> -- <claude-args>`. On first run, if `cc -c`
-   doesn't resume a session or `claude` complains about `-c`, inspect
-   `sbx run claude --help` and adjust.
-2. **Nested mount handling.** `$PWD` (RW) sits inside `~/workspace` (RO).
-   Linux bind-mount semantics say the inner mount should shadow the outer on
-   its subpath, but sbx's microVM may or may not pass that through. If
-   rejected, the script retries once with a sibling-expansion fallback (see
-   `bin/cc` plan phase).
-3. **`~/.claude` cross-visibility.** The session-persistence story hinges on
-   `~/.claude` being a live bind mount and cwd resolving to the same absolute
-   path inside the sandbox. Verify by starting a session with host `claude`,
-   exiting, running `cc -c`, and confirming the same session resumes.
-
-If any of these break in a way that can't be patched with a one-line fix,
-open an issue documenting what sbx actually does.
-
 ## Scope discipline
 
 This repo intentionally does one thing. **Do not** add:
@@ -193,3 +215,9 @@ This repo intentionally does one thing. **Do not** add:
 If a change you're considering doesn't fit in a `feat:` or `fix:` commit
 against `bin/cc`, `README.md`, `CLAUDE.md`, or `.gitignore`, it probably
 doesn't belong in this repo.
+
+**Plugin and skill installation:** plugins and skills must be installed on the
+host (`claude` without `cc`), not inside a sandbox. The sandbox mounts
+`~/.claude/plugins` and `~/.claude/skills` read-only to prevent a runaway
+sandbox from injecting malicious code into host-side executable paths. Any
+plugin installed inside a sandbox is lost when the session ends.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,50 +50,73 @@ execution.
    cwd. Build the final `sbx` argv.
 3. **Exec.** If the named sandbox doesn't exist, create it with
    `sbx create claude <primary> <mounts>`. Then inject credentials via
-   `sbx exec`. Then create sharing symlinks via `sbx exec`. Finally attach
-   with `sbx run <name> -- <claude-args>`, foregrounded with signal forwarding.
-   Propagate sbx's exit code.
+   `sbx exec -i`. Then create sharing symlinks via `sbx exec`. Finally attach
+   with `sbx exec -it <name> env ... claude <claude-args>`, replacing the
+   cc process via `exec`. Propagate sbx's exit code.
 
 The `--cc-dry-run`, `--cc-doctor`, and `--cc-no-sandbox` flags short-circuit
 the exec phase in different ways; they still run parse and the relevant parts
 of plan.
 
-## Key sbx behaviors (verified in live testing)
+## Lessons from first-run validation
 
-These were the three first-run unknowns from the original design. All are now
-resolved:
+The original design spec had three "unknowns" that live testing resolved:
 
-1. **Primary workspace path.** sbx remaps the primary workspace to
-   `/home/agent/workspace` inside the container. It does NOT preserve the
-   absolute host path for the primary mount. Additional mounts (e.g. `~/.aws`)
-   DO land at their absolute host paths inside the sandbox.
+1. **sbx arg-passing syntax:** `sbx run <sandbox> -- <claude-args>` works, but
+   `sbx run` itself misbehaves with our credential + symlink flow and sends
+   SIGKILL to claude at startup. cc uses `sbx exec` as the attach mechanism
+   instead, losing some of sbx's agent-launcher niceties but gaining reliable
+   exec.
 
-2. **Nested mounts fail.** When cwd is inside `~/workspace` and both are
-   mounted, sbx's container-start hook tries to chown the cwd's parent
-   directory (inside the RO parent mount) and fails with "Read-only file
-   system". Fix: `strip_cwd_ancestors` removes any mount that is a strict
-   ancestor of `$PWD` before passing the list to sbx.
+2. **Nested mounts:** sbx accepts overlapping mounts at the parse level but
+   its container-start hooks fail when the cwd's parent directory is under an
+   RO mount (the hook tries to write a CLAUDE.md one level above cwd and hits
+   a read-only filesystem). cc strips any mount that is an ancestor of the
+   current cwd from the resolved mount list as a general rule.
 
-3. **Auth.** Claude inside the sandbox runs as user `agent` with
-   `HOME=/home/agent`. It looks for credentials at
-   `/home/agent/.claude/.credentials.json`. A bind mount of `~/.claude` at its
-   absolute host path doesn't help because sbx has no env var flag to remap
-   `$HOME`. Fix: `inject_credentials` extracts the token from the macOS
-   Keychain non-interactively and writes it to the correct path via `sbx exec`.
+3. **`~/.claude` cross-visibility:** sbx remaps the primary workspace to
+   `/home/agent/workspace` inside the sandbox, and `HOME` is `/home/agent`.
+   The host's `~/.claude` at `/Users/pat/.claude` is not automatically
+   discovered by claude. Solution: mount specific subpaths (`projects`,
+   `plugins`, `skills`) as additional workspaces at their absolute host paths,
+   then symlink `/home/agent/.claude/{projects,plugins,skills}` to those host
+   paths post-create via `sbx exec`. Credentials are injected separately via
+   `sbx exec -i` pipe from `security find-generic-password`.
 
-4. **sbx has no env var flag.** `sbx run --help` only supports `--branch`,
-   `--memory`, `--name`, `--template`. There is no way to pass env vars via
-   sbx. Credentials and other config must be injected via `sbx exec`.
+Additional runtime surprises found during implementation:
 
-5. **Bypass mode is the default.** sbx's claude image has
-   `"defaultMode": "bypassPermissions"` pre-configured in
-   `/home/agent/.claude/settings.json`. Do not add any bypass flag as a
-   default in `cc`.
+4. **sbx rapid-call race:** Running several sbx subcommands back-to-back
+   (`create`, `exec` for inject, `exec` for symlinks, final `exec` to attach)
+   leaves the sbx daemon in a state where the next interactive exec is
+   SIGKILL'd at startup. A 1-second `sleep` before the final attach avoids
+   this. Worth reporting upstream.
 
-6. **Create vs. attach.** Passing workspace paths to an existing sandbox errors
-   with "sandbox X already exists and can't be given new workspaces". The
-   correct flow: `sbx create claude <primary> <mounts>` once, then
-   `sbx run <name>` on every subsequent attach.
+5. **`bash -x` leaks secrets:** The first version of `inject_credentials`
+   stored the extracted Keychain token in a shell variable, which `bash -x`
+   would expand and print to stderr. The current version pipes directly from
+   `security` into `sbx exec -i` without an intermediate variable.
+
+6. **TERM/COLORTERM env passthrough:** `sbx exec` does not inherit the host's
+   terminal environment. Claude inside the sandbox defaults to minimal/no-color
+   output unless we explicitly wrap the invocation in `env TERM=... COLORTERM=...`.
+
+Key sbx facts that govern the implementation:
+
+- **Primary workspace path:** sbx remaps the primary workspace to
+  `/home/agent/workspace` inside the container. It does NOT preserve the
+  absolute host path. Additional mounts (e.g. `~/.aws`) DO land at their
+  absolute host paths inside the sandbox.
+- **sbx has no env var flag:** `sbx create` only supports `--branch`,
+  `--memory`, `--name`, `--template`. Credentials and other config must be
+  injected via `sbx exec`.
+- **Bypass mode is the default:** sbx's claude image has
+  `"defaultMode": "bypassPermissions"` pre-configured in
+  `/home/agent/.claude/settings.json`. Do not add any bypass flag as a
+  default in `cc`.
+- **Create vs. attach:** Passing workspace paths to an existing sandbox errors
+  with "sandbox X already exists and can't be given new workspaces". The
+  correct flow: `sbx create claude <primary> <mounts>` once, then
+  `sbx exec` on every subsequent attach.
 
 ## Code style
 
@@ -221,3 +244,10 @@ host (`claude` without `cc`), not inside a sandbox. The sandbox mounts
 `~/.claude/plugins` and `~/.claude/skills` read-only to prevent a runaway
 sandbox from injecting malicious code into host-side executable paths. Any
 plugin installed inside a sandbox is lost when the session ends.
+
+- **Do not install plugins or skills from inside a sandbox session.** Plugins
+  and skills are mounted read-only from the host at
+  `/Users/<you>/.claude/plugins` and `/Users/<you>/.claude/skills`. A plugin
+  install from inside the sandbox will either fail or write to a scratch
+  location that vanishes when the sandbox is removed. Install plugins from
+  a host claude session instead (plain `claude`, not via `cc`).

--- a/README.md
+++ b/README.md
@@ -23,9 +23,8 @@ you explicitly mount in.
   for ad-hoc file sharing)
 - Shares `~/.claude/projects` **read-write** so sessions persist across runs
   and are visible from both host `claude` and sandboxed `cc`
-- Shares `~/.claude/plugins`, `~/.claude/skills`, and `~/.claude/CLAUDE.md`
-  **read-only** so your tools and config are available without letting a sandbox
-  session tamper with them
+- Shares `~/.claude/plugins` and `~/.claude/skills` **read-only** so your
+  tools are available without letting a sandbox session tamper with them
 - Shares `~/.aws`, `~/.config/gh`, and `~/.ssh` **read-only** so credentials
   work without letting the agent overwrite them
 - Auto-injects your Claude Code credentials from the macOS Keychain on every
@@ -60,15 +59,29 @@ you explicitly mount in.
 
 ## Install
 
-> Not yet available. Install instructions will land here once the `cc` script
-> ships. Planned form:
->
-> ```console
-> curl -fsSL https://raw.githubusercontent.com/patclarke/claude-docker-sandbox/main/bin/cc -o ~/bin/cc
-> chmod +x ~/bin/cc
-> # make sure ~/bin is on PATH
-> cc --cc-doctor
-> ```
+macOS only for now. Linux may work but is untested.
+
+```console
+# Prerequisites: Docker Desktop + sbx CLI
+brew install docker/tap/sbx
+sbx login
+
+# Install cc to ~/bin
+mkdir -p ~/bin
+curl -fsSL https://raw.githubusercontent.com/patclarke/claude-docker-sandbox/main/bin/cc -o ~/bin/cc
+chmod +x ~/bin/cc
+
+# Ensure ~/bin is on PATH (zsh; adapt for your shell)
+grep -q 'export PATH="$HOME/bin:$PATH"' ~/.zshrc || \
+    echo 'export PATH="$HOME/bin:$PATH"' >> ~/.zshrc
+exec zsh -l
+
+# Verify
+cc --cc-doctor
+```
+
+The first run of `cc` in a project directory creates `~/.config/cc/mounts.conf`
+with default mounts. Edit that file to change what gets shared with the sandbox.
 
 ## Usage
 
@@ -168,9 +181,10 @@ Written automatically the first time you run `cc`:
 ~/.claude/projects
 
 # Claude Code code/config (RO — prevents a runaway sandbox from tampering with host plugins/skills)
+# Note: sbx only accepts directories as additional workspaces, so user-level
+# ~/.claude/CLAUDE.md is not shared. Project-level CLAUDE.md in the cwd mount still applies.
 ~/.claude/plugins:ro
 ~/.claude/skills:ro
-~/.claude/CLAUDE.md:ro
 
 # Credentials (RO — read by cc on the host, injected into the sandbox via sbx exec)
 ~/.aws:ro
@@ -189,7 +203,6 @@ Written automatically the first time you run `cc`:
 | `~/.claude/projects`    | RW   | Session persistence; host ↔ sandbox visibility                 |
 | `~/.claude/plugins`     | RO   | Host plugins available in sandbox; sandbox cannot modify them  |
 | `~/.claude/skills`      | RO   | Host skills available in sandbox; sandbox cannot modify them   |
-| `~/.claude/CLAUDE.md`   | RO   | Global Claude instructions; sandbox cannot modify them         |
 | `~/.aws`                | RO   | Credentials available to code running in the sandbox           |
 | `~/.config/gh`          | RO   | `gh` CLI auth                                                  |
 | `~/.ssh`                | RO   | git over ssh                                                   |
@@ -311,14 +324,15 @@ claude -c
 - [x] Design locked in
 - [x] Repo bootstrapped with README + CLAUDE.md
 - [x] `bin/cc` script — parse, plan, preflight, exec phases
-- [x] Live sandbox testing: sbx arg syntax, mount model, and auth all resolved
-  - sbx primary workspace remapped to `/home/agent/workspace` (not absolute path)
-  - Nested mounts cause chown failures — fixed via ancestor stripping
-  - Claude runs as `agent`; credentials injected from macOS Keychain via `sbx exec`
-  - Session/plugin/skill sharing works via symlinks from `/home/agent/.claude/*`
-- [x] `cc --cc-doctor` output formatting
-- [ ] Manual validation matrix walked through end-to-end
-- [ ] Install instructions + `brew` / `curl` one-liner
+- [x] Auto-authentication from macOS Keychain
+- [x] Session history sharing via symlinks
+- [x] Plugin/skill read-only sharing
+- [x] Color-aware TTY pass-through
+- [x] `--cc-dry-run`, `--cc-doctor`, `--cc-ls`, `--cc-rm`, `--cc-no-sandbox`
+- [ ] Manual validation matrix walked through
+- [ ] Upstream issue for sbx rapid-call race (currently worked around with 1s sleep)
+- [ ] Homebrew tap / formula (future)
+- [ ] Linux support (untested)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -2,30 +2,34 @@
 
 `cc` — a small bash wrapper that runs [Claude Code](https://claude.com/claude-code)
 inside a [Docker Sandbox](https://docs.docker.com/ai/sandboxes/) microVM, so
-`--dangerously-skip-permissions` becomes a bounded risk instead of an
-unbounded one.
+unsupervised agents have a bounded blast radius instead of an unbounded one.
 
-> **Status:** Design approved, implementation in progress. The `cc` script
-> itself has not been written yet. See [Roadmap](#roadmap) for what's coming.
+> **Status:** Core implementation complete. Live sandbox testing verified. See
+> [Roadmap](#roadmap) for remaining work.
 
 ## What this solves
 
-Running `claude --dangerously-skip-permissions` on a trusted developer machine
-is a calculated but unbounded risk: an agent with unsupervised shell access can
-touch anything the user can touch. Docker Sandboxes give each agent its own
-microVM with its own filesystem, Docker daemon, and network, so a runaway
-agent is contained to what you explicitly mount in.
+Running `claude` on a trusted developer machine with unsupervised shell access
+is a calculated but unbounded risk: a runaway agent can touch anything the user
+can touch. Docker Sandboxes give each agent its own microVM with its own
+filesystem, Docker daemon, and network, so a runaway agent is contained to what
+you explicitly mount in.
 
 `cc` is a thin shell wrapper around Docker's `sbx` CLI that:
 
 - Mounts your current working directory **read-write** into the sandbox
-- Mounts a configurable allow-list of host paths **read-only** for context
+- Mounts a configurable allow-list of host paths for context
   (e.g. `~/workspace` for cross-project references, `~/Desktop` / `~/Downloads`
   for ad-hoc file sharing)
-- Shares `~/.claude` **read-write** so your Claude Code session history persists
-  across runs *and* is visible from both host `claude` and sandboxed `cc`
+- Shares `~/.claude/projects` **read-write** so sessions persist across runs
+  and are visible from both host `claude` and sandboxed `cc`
+- Shares `~/.claude/plugins`, `~/.claude/skills`, and `~/.claude/CLAUDE.md`
+  **read-only** so your tools and config are available without letting a sandbox
+  session tamper with them
 - Shares `~/.aws`, `~/.config/gh`, and `~/.ssh` **read-only** so credentials
   work without letting the agent overwrite them
+- Auto-injects your Claude Code credentials from the macOS Keychain on every
+  invocation, so the sandbox is authenticated without any manual login step
 - Forwards every non-`--cc-*` flag to `claude` inside the sandbox
 - Runs preflight checks (sbx installed, Docker running, sbx authenticated,
   `~/.claude` writable) and auto-starts Docker Desktop if it isn't already up
@@ -128,12 +132,19 @@ through to `claude` untouched.
 
 The mount plan is built on every invocation in this order:
 
-1. **Primary mount: `$PWD`** — read-write, always. Becomes sbx's main
-   workspace and the starting directory for the agent.
-2. **Config file** — `~/.config/cc/mounts.conf`, one mount per line.
-3. **`--cc-mount` flags** — appended.
-4. **`--cc-no-mount` flags** — removed.
-5. **Dedupe** — later / more specific entries win.
+1. **Primary mount: `$PWD`** — read-write, always. Remapped to
+   `/home/agent/workspace` inside the sandbox (sbx does not preserve the
+   absolute host path for the primary mount). This is the agent's starting
+   directory.
+2. **Additional mounts** — every other path in the mount list lands at its
+   absolute host path inside the sandbox (e.g. `~/.aws` is visible at
+   `/Users/you/.aws`).
+3. **Config file** — `~/.config/cc/mounts.conf`, one mount per line.
+4. **`--cc-mount` flags** — appended.
+5. **`--cc-no-mount` flags** — removed.
+6. **Ancestor stripping** — any mount whose path is a strict ancestor of `$PWD`
+   is silently removed. This prevents nested-mount failures when cwd is inside
+   `~/workspace`.
 
 ### Default `~/.config/cc/mounts.conf`
 
@@ -144,32 +155,44 @@ Written automatically the first time you run `cc`:
 # No suffix = read-write. ":ro" = read-only.
 # Non-existent paths are skipped silently at launch.
 
-# Cross-project reference (read-only view of sibling repos)
+# Cross-project reference (read-only view of sibling repos).
+# cc automatically strips any mount that's an ancestor of $PWD, so
+# this is safe even when cwd is inside ~/workspace.
 ~/workspace:ro
 
 # Ad-hoc file sharing from normal macOS locations
 ~/Desktop:ro
 ~/Downloads:ro
 
-# Host config surfaced into the sandbox
-~/.claude                 # RW — session persistence + plugins/skills
-~/.aws:ro                 # AWS credentials read-only
-~/.config/gh:ro           # gh CLI auth read-only
-~/.ssh:ro                 # git over ssh read-only
+# Claude Code session sharing (RW — sessions from host visible in sandbox and vice versa)
+~/.claude/projects
+
+# Claude Code code/config (RO — prevents a runaway sandbox from tampering with host plugins/skills)
+~/.claude/plugins:ro
+~/.claude/skills:ro
+~/.claude/CLAUDE.md:ro
+
+# Credentials (RO — read by cc on the host, injected into the sandbox via sbx exec)
+~/.aws:ro
+~/.config/gh:ro
+~/.ssh:ro
 ```
 
 ### What each mount is for
 
-| Path                 | Mode | Why                                                   |
-|----------------------|------|-------------------------------------------------------|
-| `$PWD` (launch dir)  | RW   | The actual work happens here                          |
-| `~/workspace`        | RO   | Cross-project context; writes only via launch dir     |
-| `~/Desktop`          | RO   | Share a file with the agent without moving it         |
-| `~/Downloads`        | RO   | Same, for downloaded artifacts                        |
-| `~/.claude`          | RW   | Session persistence; host ↔ sandbox visibility        |
-| `~/.aws`             | RO   | Credentials available to code running in the sandbox  |
-| `~/.config/gh`       | RO   | `gh` CLI auth                                         |
-| `~/.ssh`             | RO   | git over ssh                                          |
+| Path                    | Mode | Why                                                            |
+|-------------------------|------|----------------------------------------------------------------|
+| `$PWD` (launch dir)     | RW   | The actual work happens here                                   |
+| `~/workspace`           | RO   | Cross-project context; stripped if cwd is inside it           |
+| `~/Desktop`             | RO   | Share a file with the agent without moving it                  |
+| `~/Downloads`           | RO   | Same, for downloaded artifacts                                 |
+| `~/.claude/projects`    | RW   | Session persistence; host ↔ sandbox visibility                 |
+| `~/.claude/plugins`     | RO   | Host plugins available in sandbox; sandbox cannot modify them  |
+| `~/.claude/skills`      | RO   | Host skills available in sandbox; sandbox cannot modify them   |
+| `~/.claude/CLAUDE.md`   | RO   | Global Claude instructions; sandbox cannot modify them         |
+| `~/.aws`                | RO   | Credentials available to code running in the sandbox           |
+| `~/.config/gh`          | RO   | `gh` CLI auth                                                  |
+| `~/.ssh`                | RO   | git over ssh                                                   |
 
 ### Customizing
 
@@ -186,21 +209,51 @@ echo '~/Notes:ro' >> ~/.config/cc/mounts.conf
 
 One-off changes: use `--cc-mount` or `--cc-no-mount` on a single invocation.
 
+## Auth
+
+`cc` auto-extracts your Claude Code credentials from the macOS Keychain on
+every invocation and injects them into the sandbox before attaching. The token
+lands at `/home/agent/.claude/.credentials.json` with `600` permissions.
+
+This means:
+- No manual `/login` step when starting a new sandbox
+- Token is refreshed on every `cc` invocation, so Keychain rotations propagate
+  automatically
+- If the Keychain read fails (non-macOS, not logged into Claude Code, etc.),
+  `cc` prints a warning and continues; you can run `/login` inside the sandbox
+  once per sandbox to authenticate manually
+
+## Plugins and skills
+
+Plugins and skills from `~/.claude/plugins` and `~/.claude/skills` are mounted
+**read-only** into the sandbox. This means:
+
+- Your host plugins and skills work inside the sandbox exactly as on the host
+- Installing a plugin from inside a sandbox session does **not** persist — the
+  sandbox cannot write to those directories
+- To install a new plugin, run `claude` on the host (plain, without `cc`) and
+  install it there; it will be available in sandbox sessions automatically on
+  the next `cc` invocation
+
+This is intentional: a runaway or compromised sandbox cannot inject malicious
+code into `~/.claude/plugins` that would then execute on the host the next time
+host `claude` loads those plugins.
+
 ## Session persistence
 
-Because `~/.claude` is a **live bind mount** (not a copy), any session files
-written from inside the sandbox land in your real `~/.claude/projects/…`
-directory on the host. Inside the sandbox, `cwd` resolves to the same absolute
-host path (`sbx` preserves absolute paths), so `claude -c` finds the same
-sessions whether you're running it on the host or through `cc`.
+`~/.claude/projects` is mounted **read-write**. Any session files written from
+inside the sandbox land in your real `~/.claude/projects/…` directory on the
+host.
 
-Three properties fall out of this:
+Inside the sandbox, `cc` creates symlinks from `/home/agent/.claude/projects`
+to the host path (preserved at its absolute location by sbx). This means:
+- Conversations **survive** `sbx rm`, OS reboots, or swapping sandbox images
+- A session started with host `claude` is resumable with `cc -c`, and vice versa
 
-1. Conversations **survive** `sbx rm`, OS reboots, or swapping sandbox images
-2. A session started with host `claude` is resumable with `cc -c`, and vice
-   versa
-3. Your Claude Code plugins and skills (`~/.claude/plugins/`) are visible
-   inside the sandbox — plugin skills work identically in both environments
+Note: the primary workspace is remapped to `/home/agent/workspace` inside the
+sandbox (not the absolute host path), so session keys may differ between host
+and sandbox sessions when both are run in the same directory. Use `-c` or
+`--resume <session-id>` to be explicit about which session to resume.
 
 ## Security model
 
@@ -208,9 +261,9 @@ Three properties fall out of this:
 on your host filesystem is invisible.
 
 **What the sandbox can modify:** only the `$PWD` you launched from and
-`~/.claude`. Everything else in the default mount list is read-only, so a
-runaway agent cannot rewrite your credentials, overwrite sibling projects, or
-touch your Desktop files.
+`~/.claude/projects`. Everything else in the default mount list is read-only,
+so a runaway agent cannot rewrite your credentials, overwrite sibling projects,
+touch your Desktop files, or modify your plugins and skills.
 
 **What isolates the sandbox from your host:** microVM (hypervisor-level)
 isolation via Docker Sandboxes. Each sandbox has its own Linux kernel,
@@ -218,13 +271,9 @@ filesystem, Docker daemon, and network namespace. Outbound traffic routes
 through an HTTP/HTTPS proxy on your host for credential injection and network
 policy.
 
-**What `--dangerously-skip-permissions` buys you** inside this model: the
-ability to run unsupervised agents that install packages, run `git` commands,
-and execute shell tools without a per-command prompt, while the blast radius
-stays bounded by the mount list. It's still a calculated risk — read-only
-mounts are exfiltration surfaces, and anything in `$PWD` or `~/.claude` is
-writable — but you're now trading "anything on my Mac" for "anything in these
-specific directories."
+**sbx's claude image** runs in bypass-permissions mode by default — no extra
+flags needed. The bounded blast radius comes from the mount list, not from
+permission prompts.
 
 ## Preflight checks
 
@@ -261,11 +310,14 @@ claude -c
 
 - [x] Design locked in
 - [x] Repo bootstrapped with README + CLAUDE.md
-- [ ] `bin/cc` script — parse, plan, preflight, exec phases
-- [ ] First-run verification of the three unknowns: sbx arg-passing syntax,
-      nested-mount handling, `~/.claude` cross-visibility
-- [ ] `cc --cc-doctor` output formatting
-- [ ] Manual validation matrix walked through
+- [x] `bin/cc` script — parse, plan, preflight, exec phases
+- [x] Live sandbox testing: sbx arg syntax, mount model, and auth all resolved
+  - sbx primary workspace remapped to `/home/agent/workspace` (not absolute path)
+  - Nested mounts cause chown failures — fixed via ancestor stripping
+  - Claude runs as `agent`; credentials injected from macOS Keychain via `sbx exec`
+  - Session/plugin/skill sharing works via symlinks from `/home/agent/.claude/*`
+- [x] `cc --cc-doctor` output formatting
+- [ ] Manual validation matrix walked through end-to-end
 - [ ] Install instructions + `brew` / `curl` one-liner
 
 ## License

--- a/bin/cc
+++ b/bin/cc
@@ -58,6 +58,13 @@ preflight_docker() {
 	return 0
 }
 
+preflight_sbx_auth() {
+	if ! sbx ls >/dev/null 2>&1; then
+		die "sbx is not authenticated. Run: sbx login"
+	fi
+	return 0
+}
+
 usage() {
 	cat <<'EOF'
 cc — run Claude Code inside a Docker Sandbox microVM
@@ -175,7 +182,8 @@ main() {
 	fi
 	preflight_sbx || return 1
 	preflight_docker || return 1
-	echo "cc $CC_VERSION: preflight OK through docker" >&2
+	preflight_sbx_auth || return 1
+	echo "cc $CC_VERSION: preflight OK through sbx auth" >&2
 	return 0
 }
 

--- a/bin/cc
+++ b/bin/cc
@@ -110,6 +110,33 @@ run_ls() {
 	sbx ls
 }
 
+run_rm() {
+	preflight_sbx || die_preflight sbx
+	ensure_docker_running
+	preflight_sbx_auth || die_preflight sbx_auth
+
+	local target
+	if [[ -n "$CC_RM_NAME" ]]; then
+		target="$CC_RM_NAME"
+	else
+		target="$(compute_sandbox_name)"
+	fi
+
+	if ! sandbox_exists "$target"; then
+		echo "cc: no sandbox named '$target'" >&2
+		return 1
+	fi
+
+	printf 'cc: remove sandbox "%s"? [y/N] ' "$target" >&2
+	local reply
+	read -r reply
+	if [[ "$reply" != "y" && "$reply" != "Y" ]]; then
+		echo "cc: aborted." >&2
+		return 1
+	fi
+	sbx rm "$target"
+}
+
 run_doctor() {
 	local fails=0
 	echo "cc doctor"
@@ -610,6 +637,10 @@ main() {
 	fi
 	if [[ $CC_LS -eq 1 ]]; then
 		run_ls
+		return $?
+	fi
+	if [[ $CC_RM -eq 1 ]]; then
+		run_rm
 		return $?
 	fi
 	if [[ $CC_DRY_RUN -eq 1 ]]; then

--- a/bin/cc
+++ b/bin/cc
@@ -161,6 +161,13 @@ run_doctor() {
 		done
 	fi
 
+	# shellcheck disable=SC2088
+	if [[ -f "$CC_MOUNTS_FILE" ]] && ! grep -q '~/\.claude/projects' "$CC_MOUNTS_FILE"; then
+		echo
+		echo "WARN: ~/.config/cc/mounts.conf looks out of date (missing ~/.claude/projects)."
+		echo "      Consider deleting it to regenerate with current defaults."
+	fi
+
 	echo
 	if ((fails > 0)); then
 		echo "$fails check(s) failed."
@@ -226,18 +233,27 @@ write_default_mounts_file() {
 # No suffix = read-write. ":ro" = read-only.
 # Non-existent paths are skipped silently at launch.
 
-# Cross-project reference (read-only view of sibling repos)
+# Cross-project reference (read-only view of sibling repos).
+# cc automatically strips any mount that's an ancestor of $PWD, so
+# this is safe even when cwd is inside ~/workspace.
 ~/workspace:ro
 
 # Ad-hoc file sharing from normal macOS locations
 ~/Desktop:ro
 ~/Downloads:ro
 
-# Host config surfaced into the sandbox
-~/.claude                 # RW — session persistence + plugins/skills
-~/.aws:ro                 # AWS credentials read-only
-~/.config/gh:ro           # gh CLI auth read-only
-~/.ssh:ro                 # git over ssh read-only
+# Claude Code session sharing (RW — sessions from host visible in sandbox and vice versa)
+~/.claude/projects
+
+# Claude Code code/config (RO — prevents a runaway sandbox from tampering with host plugins/skills)
+~/.claude/plugins:ro
+~/.claude/skills:ro
+~/.claude/CLAUDE.md:ro
+
+# Credentials (RO — read by cc on the host, injected into the sandbox via sbx exec)
+~/.aws:ro
+~/.config/gh:ro
+~/.ssh:ro
 EOF
 	echo "cc: created $CC_MOUNTS_FILE with defaults." >&2
 }
@@ -315,6 +331,7 @@ resolve_mounts() {
 		CC_RESOLVED_MOUNTS=("${new_list[@]+"${new_list[@]}"}")
 	done
 	filter_existing_mounts
+	strip_cwd_ancestors
 }
 
 filter_existing_mounts() {
@@ -324,6 +341,21 @@ filter_existing_mounts() {
 		if [[ -e "$path" ]]; then
 			kept+=("$entry")
 		fi
+	done
+	CC_RESOLVED_MOUNTS=("${kept[@]+"${kept[@]}"}")
+}
+
+strip_cwd_ancestors() {
+	local pwd_abs kept=() entry path
+	pwd_abs="$(pwd -P)"
+	for entry in "${CC_RESOLVED_MOUNTS[@]+"${CC_RESOLVED_MOUNTS[@]}"}"; do
+		path="$(mount_path_only "$entry")"
+		# Strip if cwd is strictly UNDER this mount (ancestor). Equal is fine — that's the primary.
+		if [[ "$pwd_abs" == "$path"/* && "$pwd_abs" != "$path" ]]; then
+			echo "cc: stripping ancestor mount $path (cwd is inside it)" >&2
+			continue
+		fi
+		kept+=("$entry")
 	done
 	CC_RESOLVED_MOUNTS=("${kept[@]+"${kept[@]}"}")
 }

--- a/bin/cc
+++ b/bin/cc
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+#
+# cc — run Claude Code inside a Docker Sandbox microVM
+# https://github.com/patclarke/claude-docker-sandbox
+
+set -euo pipefail
+
+readonly CC_VERSION="0.1.0"
+
+main() {
+	echo "cc $CC_VERSION: not yet implemented" >&2
+	return 0
+}
+
+main "$@"

--- a/bin/cc
+++ b/bin/cc
@@ -55,7 +55,7 @@ EOF
 		echo "cc: claude binary not found on PATH." >&2
 		;;
 	esac
-	return 1
+	exit 1
 }
 
 ensure_docker_running() {

--- a/bin/cc
+++ b/bin/cc
@@ -422,15 +422,27 @@ dry_run_output() {
 	load_mounts_config
 	resolve_mounts
 	build_sbx_argv
+
+	local pwd_abs
+	pwd_abs="$(pwd -P)"
+
 	echo "# cc dry-run"
+	echo "CWD=$pwd_abs"
 	echo "SANDBOX_NAME=$(compute_sandbox_name)"
-	echo "CC_NO_SANDBOX=${CC_NO_SANDBOX}"
-	echo "RESOLVED_MOUNTS:"
-	local m
-	for m in "${CC_RESOLVED_MOUNTS[@]+"${CC_RESOLVED_MOUNTS[@]}"}"; do
-		echo "  $m"
-	done
-	echo "CLAUDE_ARGS=(${CLAUDE_ARGS[*]:-})"
+	echo "NO_SANDBOX=$CC_NO_SANDBOX"
+	echo
+	echo "MOUNTS (resolved, existing only):"
+	if [[ ${#CC_RESOLVED_MOUNTS[@]} -eq 0 ]]; then
+		echo "  (none)"
+	else
+		local m
+		for m in "${CC_RESOLVED_MOUNTS[@]}"; do
+			echo "  $m"
+		done
+	fi
+	echo
+	echo "CLAUDE_ARGS: ${CLAUDE_ARGS[*]:-<none>}"
+	echo
 	echo "COMMAND:"
 	printf '  %q ' "${CC_SBX_ARGV[@]}"
 	echo

--- a/bin/cc
+++ b/bin/cc
@@ -3,7 +3,6 @@
 # cc — run Claude Code inside a Docker Sandbox microVM
 # https://github.com/patclarke/claude-docker-sandbox
 
-# shellcheck disable=SC2034
 set -euo pipefail
 
 readonly CC_VERSION="0.1.0"
@@ -213,8 +212,8 @@ run_doctor() {
 }
 
 usage() {
-	cat <<'EOF'
-cc — run Claude Code inside a Docker Sandbox microVM
+	cat <<EOF
+cc $CC_VERSION — run Claude Code inside a Docker Sandbox microVM
 
 USAGE:
     cc [CC_FLAGS] [CLAUDE_ARGS...]

--- a/bin/cc
+++ b/bin/cc
@@ -215,6 +215,7 @@ CC_EXTRA_MOUNTS=()
 CC_SKIP_MOUNTS=()
 CC_CONFIG_MOUNTS=()
 CC_RESOLVED_MOUNTS=()
+CC_SBX_ARGV=()
 CLAUDE_ARGS=()
 
 write_default_mounts_file() {
@@ -339,6 +340,29 @@ compute_sandbox_name() {
 	echo "${basename}-${hash}"
 }
 
+build_sbx_argv() {
+	local name pwd_abs
+	name="$(compute_sandbox_name)"
+	pwd_abs="$(pwd -P)"
+
+	CC_SBX_ARGV=(sbx run claude --name "$name" "$pwd_abs")
+
+	# Append every resolved mount whose path is not the primary (cwd)
+	local entry path
+	for entry in "${CC_RESOLVED_MOUNTS[@]+"${CC_RESOLVED_MOUNTS[@]}"}"; do
+		path="$(mount_path_only "$entry")"
+		if [[ "$path" == "$pwd_abs" ]]; then
+			continue
+		fi
+		CC_SBX_ARGV+=("$entry")
+	done
+
+	if [[ ${#CLAUDE_ARGS[@]} -gt 0 ]]; then
+		CC_SBX_ARGV+=(--)
+		CC_SBX_ARGV+=("${CLAUDE_ARGS[@]}")
+	fi
+}
+
 parse_args() {
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
@@ -397,6 +421,7 @@ parse_args() {
 dry_run_output() {
 	load_mounts_config
 	resolve_mounts
+	build_sbx_argv
 	echo "# cc dry-run"
 	echo "SANDBOX_NAME=$(compute_sandbox_name)"
 	echo "CC_NO_SANDBOX=${CC_NO_SANDBOX}"
@@ -406,6 +431,9 @@ dry_run_output() {
 		echo "  $m"
 	done
 	echo "CLAUDE_ARGS=(${CLAUDE_ARGS[*]:-})"
+	echo "COMMAND:"
+	printf '  %q ' "${CC_SBX_ARGV[@]}"
+	echo
 }
 
 main() {

--- a/bin/cc
+++ b/bin/cc
@@ -13,6 +13,18 @@ die() {
 	exit 1
 }
 
+preflight_sbx() {
+	if ! command -v sbx >/dev/null 2>&1; then
+		cat >&2 <<'EOF'
+cc: sbx not found on PATH.
+    Install:   brew install docker/tap/sbx
+    Then run:  sbx login
+EOF
+		return 1
+	fi
+	return 0
+}
+
 usage() {
 	cat <<'EOF'
 cc — run Claude Code inside a Docker Sandbox microVM
@@ -128,7 +140,8 @@ main() {
 		dry_run_output
 		return 0
 	fi
-	echo "cc $CC_VERSION: plan+exec not yet implemented" >&2
+	preflight_sbx || return 1
+	echo "cc $CC_VERSION: preflight_sbx OK" >&2
 	return 0
 }
 

--- a/bin/cc
+++ b/bin/cc
@@ -7,7 +7,48 @@ set -euo pipefail
 
 readonly CC_VERSION="0.1.0"
 
+usage() {
+	cat <<'EOF'
+cc — run Claude Code inside a Docker Sandbox microVM
+
+USAGE:
+    cc [CC_FLAGS] [CLAUDE_ARGS...]
+
+WRAPPER FLAGS (consumed by cc, not forwarded):
+    --cc-name <label>       Named sandbox for parallelism
+    --cc-mount <path>[:ro]  Add an extra mount for this invocation (repeatable)
+    --cc-no-mount <path>    Skip a config-file mount for this invocation (repeatable)
+    --cc-no-sandbox         Escape hatch — exec host claude directly
+    --cc-rm [name]          Remove the sandbox for cwd (or the named one)
+    --cc-ls                 List active sandboxes
+    --cc-dry-run            Print the resolved sbx run command, do not exec
+    --cc-doctor             Run preflight checks + show resolved mount list
+    --cc-help, -h           Show this help
+
+Everything else is forwarded to claude inside the sandbox.
+
+EXAMPLES:
+    cc                          # fresh session in cwd
+    cc -c                       # resume most recent session in cwd
+    cc --remote-control -c      # forward arbitrary claude flags
+    cc --cc-name exp-a -c       # named parallel sandbox
+    cc --cc-mount ~/notes:ro    # ad-hoc extra mount
+    cc --cc-no-sandbox -c       # bypass the sandbox entirely
+
+CONFIG:
+    ~/.config/cc/mounts.conf    Durable mount policy (created on first run)
+EOF
+}
+
 main() {
+	if [[ $# -gt 0 ]]; then
+		case "$1" in
+		--cc-help | -h)
+			usage
+			return 0
+			;;
+		esac
+	fi
 	echo "cc $CC_VERSION: not yet implemented" >&2
 	return 0
 }

--- a/bin/cc
+++ b/bin/cc
@@ -293,6 +293,18 @@ resolve_mounts() {
 		done
 		CC_RESOLVED_MOUNTS=("${new_list[@]+"${new_list[@]}"}")
 	done
+	filter_existing_mounts
+}
+
+filter_existing_mounts() {
+	local kept=() entry path
+	for entry in "${CC_RESOLVED_MOUNTS[@]+"${CC_RESOLVED_MOUNTS[@]}"}"; do
+		path="$(mount_path_only "$entry")"
+		if [[ -e "$path" ]]; then
+			kept+=("$entry")
+		fi
+	done
+	CC_RESOLVED_MOUNTS=("${kept[@]+"${kept[@]}"}")
 }
 
 parse_args() {

--- a/bin/cc
+++ b/bin/cc
@@ -327,6 +327,18 @@ filter_existing_mounts() {
 	CC_RESOLVED_MOUNTS=("${kept[@]+"${kept[@]}"}")
 }
 
+compute_sandbox_name() {
+	if [[ -n "$CC_NAME" ]]; then
+		echo "$CC_NAME"
+		return 0
+	fi
+	local abs basename hash
+	abs="$(pwd -P)"
+	basename="$(basename "$abs")"
+	hash="$(printf '%s' "$abs" | shasum -a 1 | cut -c1-6)"
+	echo "${basename}-${hash}"
+}
+
 parse_args() {
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
@@ -386,7 +398,7 @@ dry_run_output() {
 	load_mounts_config
 	resolve_mounts
 	echo "# cc dry-run"
-	echo "CC_NAME=${CC_NAME:-<derived>}"
+	echo "SANDBOX_NAME=$(compute_sandbox_name)"
 	echo "CC_NO_SANDBOX=${CC_NO_SANDBOX}"
 	echo "RESOLVED_MOUNTS:"
 	local m

--- a/bin/cc
+++ b/bin/cc
@@ -194,6 +194,7 @@ CC_RM_NAME=""
 CC_EXTRA_MOUNTS=()
 CC_SKIP_MOUNTS=()
 CC_CONFIG_MOUNTS=()
+CC_RESOLVED_MOUNTS=()
 CLAUDE_ARGS=()
 
 write_default_mounts_file() {
@@ -241,6 +242,57 @@ load_mounts_config() {
 		fi
 		CC_CONFIG_MOUNTS+=("$line")
 	done <"$CC_MOUNTS_FILE"
+}
+
+mount_path_only() {
+	# strip :ro suffix, expand leading ~
+	local entry="$1"
+	local path="${entry%:ro}"
+	# shellcheck disable=SC2088
+	if [[ "$path" == "~/"* ]]; then
+		path="$HOME/${path:2}"
+	elif [[ "$path" == "~" ]]; then
+		path="$HOME"
+	fi
+	echo "$path"
+}
+
+resolve_mounts() {
+	CC_RESOLVED_MOUNTS=("${CC_CONFIG_MOUNTS[@]+"${CC_CONFIG_MOUNTS[@]}"}")
+
+	# Append --cc-mount entries (expand ~)
+	local extra expanded suffix path
+	for extra in "${CC_EXTRA_MOUNTS[@]+"${CC_EXTRA_MOUNTS[@]}"}"; do
+		suffix=""
+		path="$extra"
+		if [[ "$extra" == *:ro ]]; then
+			suffix=":ro"
+			path="${extra%:ro}"
+		fi
+		# shellcheck disable=SC2088
+		if [[ "$path" == "~/"* ]]; then
+			expanded="$HOME/${path:2}$suffix"
+		elif [[ "$path" == "~" ]]; then
+			expanded="$HOME$suffix"
+		else
+			expanded="$path$suffix"
+		fi
+		CC_RESOLVED_MOUNTS+=("$expanded")
+	done
+
+	# Remove --cc-no-mount entries by absolute-path match
+	local skip skip_abs new_list current current_abs
+	for skip in "${CC_SKIP_MOUNTS[@]+"${CC_SKIP_MOUNTS[@]}"}"; do
+		skip_abs="$(mount_path_only "$skip")"
+		new_list=()
+		for current in "${CC_RESOLVED_MOUNTS[@]+"${CC_RESOLVED_MOUNTS[@]}"}"; do
+			current_abs="$(mount_path_only "$current")"
+			if [[ "$current_abs" != "$skip_abs" ]]; then
+				new_list+=("$current")
+			fi
+		done
+		CC_RESOLVED_MOUNTS=("${new_list[@]+"${new_list[@]}"}")
+	done
 }
 
 parse_args() {
@@ -300,16 +352,15 @@ parse_args() {
 
 dry_run_output() {
 	load_mounts_config
+	resolve_mounts
 	echo "# cc dry-run"
 	echo "CC_NAME=${CC_NAME:-<derived>}"
 	echo "CC_NO_SANDBOX=${CC_NO_SANDBOX}"
-	echo "CC_CONFIG_MOUNTS:"
+	echo "RESOLVED_MOUNTS:"
 	local m
-	for m in "${CC_CONFIG_MOUNTS[@]+"${CC_CONFIG_MOUNTS[@]}"}"; do
+	for m in "${CC_RESOLVED_MOUNTS[@]+"${CC_RESOLVED_MOUNTS[@]}"}"; do
 		echo "  $m"
 	done
-	echo "CC_EXTRA_MOUNTS=(${CC_EXTRA_MOUNTS[*]:-})"
-	echo "CC_SKIP_MOUNTS=(${CC_SKIP_MOUNTS[*]:-})"
 	echo "CLAUDE_ARGS=(${CLAUDE_ARGS[*]:-})"
 }
 

--- a/bin/cc
+++ b/bin/cc
@@ -142,6 +142,26 @@ run_doctor() {
 	fi
 
 	echo
+	echo "Mount plan (from $CC_MOUNTS_FILE):"
+	load_mounts_config
+	resolve_mounts
+	if [[ ${#CC_RESOLVED_MOUNTS[@]} -eq 0 ]]; then
+		echo "  (empty)"
+	else
+		local entry mode path
+		for entry in "${CC_RESOLVED_MOUNTS[@]}"; do
+			if [[ "$entry" == *:ro ]]; then
+				mode="RO"
+				path="${entry%:ro}"
+			else
+				mode="RW"
+				path="$entry"
+			fi
+			printf '  %-3s %s\n' "$mode" "$path"
+		done
+	fi
+
+	echo
 	if ((fails > 0)); then
 		echo "$fails check(s) failed."
 		return 1

--- a/bin/cc
+++ b/bin/cc
@@ -223,6 +223,7 @@ CC_SKIP_MOUNTS=()
 CC_CONFIG_MOUNTS=()
 CC_RESOLVED_MOUNTS=()
 CC_SBX_ARGV=()
+CC_CREATE_ARGV=()
 CLAUDE_ARGS=()
 
 write_default_mounts_file() {
@@ -372,22 +373,64 @@ compute_sandbox_name() {
 	echo "${basename}-${hash}"
 }
 
+sandbox_exists() {
+	local name="$1"
+	sbx ls 2>/dev/null | awk 'NR>1 {print $1}' | grep -qx "$name"
+}
+
+inject_credentials() {
+	local name="$1" token
+	if ! token="$(security find-generic-password -s 'Claude Code-credentials' -a "$USER" -w 2>/dev/null)"; then
+		echo "cc: no Claude Code credentials in macOS Keychain; sandbox claude may prompt /login" >&2
+		return 0
+	fi
+	printf '%s' "$token" | sbx exec -i "$name" sh -c '
+		mkdir -p /home/agent/.claude &&
+		cat > /home/agent/.claude/.credentials.json &&
+		chmod 600 /home/agent/.claude/.credentials.json
+	' >/dev/null 2>&1 || {
+		echo "cc: failed to inject credentials into sandbox (sandbox may prompt /login)" >&2
+		return 0
+	}
+	return 0
+}
+
+setup_share_symlinks() {
+	local name="$1" home="$HOME"
+	sbx exec "$name" sh -c "
+		[ -d '$home/.claude/projects' ] && {
+			[ -L /home/agent/.claude/projects ] || {
+				rm -rf /home/agent/.claude/projects
+				ln -s '$home/.claude/projects' /home/agent/.claude/projects
+			}
+		}
+		[ -d '$home/.claude/plugins' ] && {
+			[ -L /home/agent/.claude/plugins ] || {
+				rm -rf /home/agent/.claude/plugins
+				ln -s '$home/.claude/plugins' /home/agent/.claude/plugins
+			}
+		}
+		[ -d '$home/.claude/skills' ] && {
+			[ -L /home/agent/.claude/skills ] || {
+				rm -rf /home/agent/.claude/skills
+				ln -s '$home/.claude/skills' /home/agent/.claude/skills
+			}
+		}
+		[ -f '$home/.claude/CLAUDE.md' ] && {
+			[ -L /home/agent/.claude/CLAUDE.md ] || {
+				ln -sf '$home/.claude/CLAUDE.md' /home/agent/.claude/CLAUDE.md
+			}
+		}
+		exit 0
+	" >/dev/null 2>&1 || true
+}
+
 build_sbx_argv() {
-	local name pwd_abs
+	# Always show the attach form (name-only + claude args) — that's what runs in the hot path.
+	local name
 	name="$(compute_sandbox_name)"
-	pwd_abs="$(pwd -P)"
 
-	CC_SBX_ARGV=(sbx run claude --name "$name" "$pwd_abs")
-
-	# Append every resolved mount whose path is not the primary (cwd)
-	local entry path
-	for entry in "${CC_RESOLVED_MOUNTS[@]+"${CC_RESOLVED_MOUNTS[@]}"}"; do
-		path="$(mount_path_only "$entry")"
-		if [[ "$path" == "$pwd_abs" ]]; then
-			continue
-		fi
-		CC_SBX_ARGV+=("$entry")
-	done
+	CC_SBX_ARGV=(sbx run "$name")
 
 	if [[ ${#CLAUDE_ARGS[@]} -gt 0 ]]; then
 		CC_SBX_ARGV+=(--)
@@ -395,9 +438,47 @@ build_sbx_argv() {
 	fi
 }
 
+build_create_argv() {
+	# Build the sbx create argv for --cc-dry-run display and actual creation.
+	local name pwd_abs
+	name="$(compute_sandbox_name)"
+	pwd_abs="$(pwd -P)"
+
+	CC_CREATE_ARGV=(sbx create claude "$pwd_abs" --name "$name")
+
+	local entry path
+	for entry in "${CC_RESOLVED_MOUNTS[@]+"${CC_RESOLVED_MOUNTS[@]}"}"; do
+		path="$(mount_path_only "$entry")"
+		if [[ "$path" == "$pwd_abs" ]]; then
+			continue
+		fi
+		CC_CREATE_ARGV+=("$entry")
+	done
+}
+
 run_sandbox() {
 	build_sbx_argv
+	local name
+	name="$(compute_sandbox_name)"
 
+	# Step 1: create sandbox if it doesn't exist yet
+	if ! sandbox_exists "$name"; then
+		local create_argv=()
+		build_create_argv
+		create_argv=("${CC_CREATE_ARGV[@]}")
+		"${create_argv[@]}" || {
+			echo "cc: failed to create sandbox $name" >&2
+			return 1
+		}
+	fi
+
+	# Step 2: inject credentials (idempotent, refreshes token each run)
+	inject_credentials "$name"
+
+	# Step 3: set up sharing symlinks (idempotent)
+	setup_share_symlinks "$name"
+
+	# Step 4: attach via sbx run NAME -- CLAUDE_ARGS (no workspace args)
 	local sbx_pid rc=0
 	"${CC_SBX_ARGV[@]}" &
 	sbx_pid=$!

--- a/bin/cc
+++ b/bin/cc
@@ -113,9 +113,22 @@ parse_args() {
 	done
 }
 
+dry_run_output() {
+	echo "# cc dry-run"
+	echo "CC_NAME=${CC_NAME:-<derived>}"
+	echo "CC_NO_SANDBOX=${CC_NO_SANDBOX}"
+	echo "CC_EXTRA_MOUNTS=(${CC_EXTRA_MOUNTS[*]:-})"
+	echo "CC_SKIP_MOUNTS=(${CC_SKIP_MOUNTS[*]:-})"
+	echo "CLAUDE_ARGS=(${CLAUDE_ARGS[*]:-})"
+}
+
 main() {
 	parse_args "$@"
-	echo "parsed OK. claude_args=(${CLAUDE_ARGS[*]:-})" >&2
+	if [[ $CC_DRY_RUN -eq 1 ]]; then
+		dry_run_output
+		return 0
+	fi
+	echo "cc $CC_VERSION: plan+exec not yet implemented" >&2
 	return 0
 }
 

--- a/bin/cc
+++ b/bin/cc
@@ -397,6 +397,10 @@ inject_credentials() {
 
 setup_share_symlinks() {
 	local name="$1" home="$HOME"
+	# Redirect stdin from /dev/null so this sbx exec doesn't steal cc's stdin.
+	# Without the redirect, sbx exec inherits cc's stdin and consumes it, which
+	# leaves the final `sbx exec -i ... claude` attach with no stdin and claude
+	# gets SIGKILL'd (exit 137).
 	sbx exec "$name" sh -c "
 		[ -d '$home/.claude/projects' ] && {
 			[ -L /home/agent/.claude/projects ] || {
@@ -417,7 +421,7 @@ setup_share_symlinks() {
 			}
 		}
 		exit 0
-	" >/dev/null 2>&1 || true
+	" </dev/null >/dev/null 2>&1 || true
 }
 
 build_sbx_argv() {
@@ -480,12 +484,17 @@ run_sandbox() {
 	# Step 3: set up sharing symlinks (idempotent)
 	setup_share_symlinks "$name"
 
-	# Step 4: attach to sandbox via sbx exec, running claude in foreground.
-	# Do NOT background-and-wait — sbx exec needs connected stdin/stdout/stderr
-	# to pass through to claude, and the `&` + `wait` pattern can sever stdio.
-	# Signal handling: bash in foreground-exec mode forwards SIGINT/SIGTERM
-	# to the child as long as the child is the only process in the job.
-	"${CC_SBX_ARGV[@]}"
+	# sbx race workaround: rapid successive sbx calls (create, exec for inject,
+	# exec for symlinks, then exec for attach) leave the sbx daemon in a state
+	# where the interactive attach is SIGKILL'd at startup (exit 137). A brief
+	# pause before the attach lets the daemon settle. 1s is sufficient in
+	# practice; under 1s is unreliable.
+	sleep 1
+
+	# Step 4: exec into sbx exec so cc's process becomes sbx exec entirely.
+	# Using `exec` avoids any parent-child stdio/signal layering issues
+	# between cc and the attach command.
+	exec "${CC_SBX_ARGV[@]}"
 }
 
 parse_args() {

--- a/bin/cc
+++ b/bin/cc
@@ -7,6 +7,8 @@
 set -euo pipefail
 
 readonly CC_VERSION="0.1.0"
+readonly CC_CONFIG_DIR="$HOME/.config/cc"
+readonly CC_MOUNTS_FILE="$CC_CONFIG_DIR/mounts.conf"
 
 die() {
 	echo "cc: $*" >&2
@@ -191,7 +193,55 @@ CC_RM=0
 CC_RM_NAME=""
 CC_EXTRA_MOUNTS=()
 CC_SKIP_MOUNTS=()
+CC_CONFIG_MOUNTS=()
 CLAUDE_ARGS=()
+
+write_default_mounts_file() {
+	mkdir -p "$CC_CONFIG_DIR"
+	cat >"$CC_MOUNTS_FILE" <<'EOF'
+# cc mounts config
+# Format:  <path>[:ro]
+# No suffix = read-write. ":ro" = read-only.
+# Non-existent paths are skipped silently at launch.
+
+# Cross-project reference (read-only view of sibling repos)
+~/workspace:ro
+
+# Ad-hoc file sharing from normal macOS locations
+~/Desktop:ro
+~/Downloads:ro
+
+# Host config surfaced into the sandbox
+~/.claude                 # RW — session persistence + plugins/skills
+~/.aws:ro                 # AWS credentials read-only
+~/.config/gh:ro           # gh CLI auth read-only
+~/.ssh:ro                 # git over ssh read-only
+EOF
+	echo "cc: created $CC_MOUNTS_FILE with defaults." >&2
+}
+
+load_mounts_config() {
+	if [[ ! -f "$CC_MOUNTS_FILE" ]]; then
+		write_default_mounts_file
+	fi
+	CC_CONFIG_MOUNTS=()
+	local line
+	while IFS= read -r line || [[ -n "$line" ]]; do
+		# strip inline comments and trailing whitespace
+		line="${line%%#*}"
+		line="${line%"${line##*[![:space:]]}"}"
+		line="${line#"${line%%[![:space:]]*}"}"
+		[[ -z "$line" ]] && continue
+		# expand leading ~
+		# shellcheck disable=SC2088
+		if [[ "$line" == "~/"* ]]; then
+			line="$HOME/${line:2}"
+		elif [[ "$line" == "~" ]]; then
+			line="$HOME"
+		fi
+		CC_CONFIG_MOUNTS+=("$line")
+	done <"$CC_MOUNTS_FILE"
+}
 
 parse_args() {
 	while [[ $# -gt 0 ]]; do
@@ -249,9 +299,15 @@ parse_args() {
 }
 
 dry_run_output() {
+	load_mounts_config
 	echo "# cc dry-run"
 	echo "CC_NAME=${CC_NAME:-<derived>}"
 	echo "CC_NO_SANDBOX=${CC_NO_SANDBOX}"
+	echo "CC_CONFIG_MOUNTS:"
+	local m
+	for m in "${CC_CONFIG_MOUNTS[@]+"${CC_CONFIG_MOUNTS[@]}"}"; do
+		echo "  $m"
+	done
 	echo "CC_EXTRA_MOUNTS=(${CC_EXTRA_MOUNTS[*]:-})"
 	echo "CC_SKIP_MOUNTS=(${CC_SKIP_MOUNTS[*]:-})"
 	echo "CLAUDE_ARGS=(${CLAUDE_ARGS[*]:-})"

--- a/bin/cc
+++ b/bin/cc
@@ -247,9 +247,10 @@ write_default_mounts_file() {
 ~/.claude/projects
 
 # Claude Code code/config (RO — prevents a runaway sandbox from tampering with host plugins/skills)
+# Note: sbx only accepts directories as additional workspaces, so user-level
+# ~/.claude/CLAUDE.md is not shared. Project-level CLAUDE.md in the cwd mount still applies.
 ~/.claude/plugins:ro
 ~/.claude/skills:ro
-~/.claude/CLAUDE.md:ro
 
 # Credentials (RO — read by cc on the host, injected into the sandbox via sbx exec)
 ~/.aws:ro
@@ -414,11 +415,6 @@ setup_share_symlinks() {
 			[ -L /home/agent/.claude/skills ] || {
 				rm -rf /home/agent/.claude/skills
 				ln -s '$home/.claude/skills' /home/agent/.claude/skills
-			}
-		}
-		[ -f '$home/.claude/CLAUDE.md' ] && {
-			[ -L /home/agent/.claude/CLAUDE.md ] || {
-				ln -sf '$home/.claude/CLAUDE.md' /home/agent/.claude/CLAUDE.md
 			}
 		}
 		exit 0

--- a/bin/cc
+++ b/bin/cc
@@ -76,6 +76,25 @@ preflight_claude_dir() {
 	return 0
 }
 
+preflight_claude_binary() {
+	if ! command -v claude >/dev/null 2>&1; then
+		die "claude binary not found on PATH. Install Claude Code and ensure it is on PATH."
+	fi
+	return 0
+}
+
+run_preflight() {
+	if [[ $CC_NO_SANDBOX -eq 1 ]]; then
+		preflight_claude_binary || return 1
+		return 0
+	fi
+	preflight_sbx || return 1
+	preflight_docker || return 1
+	preflight_sbx_auth || return 1
+	preflight_claude_dir || return 1
+	return 0
+}
+
 usage() {
 	cat <<'EOF'
 cc — run Claude Code inside a Docker Sandbox microVM
@@ -191,11 +210,8 @@ main() {
 		dry_run_output
 		return 0
 	fi
-	preflight_sbx || return 1
-	preflight_docker || return 1
-	preflight_sbx_auth || return 1
-	preflight_claude_dir || return 1
-	echo "cc $CC_VERSION: preflight OK" >&2
+	run_preflight || return 1
+	echo "cc $CC_VERSION: preflight OK (no_sandbox=$CC_NO_SANDBOX)" >&2
 	return 0
 }
 

--- a/bin/cc
+++ b/bin/cc
@@ -380,19 +380,18 @@ sandbox_exists() {
 }
 
 inject_credentials() {
-	local name="$1" token
-	if ! token="$(security find-generic-password -s 'Claude Code-credentials' -a "$USER" -w 2>/dev/null)"; then
-		echo "cc: no Claude Code credentials in macOS Keychain; sandbox claude may prompt /login" >&2
-		return 0
+	local name="$1"
+	# SECURITY: never assign the token to a shell variable — `bash -x` would
+	# expand it and leak the secret to stderr. Pipe straight from `security`
+	# into `sbx exec -i` so the token exists only in the stdin pipe.
+	if ! security find-generic-password -s 'Claude Code-credentials' -a "$USER" -w 2>/dev/null |
+		sbx exec -i "$name" sh -c '
+			mkdir -p /home/agent/.claude &&
+			cat > /home/agent/.claude/.credentials.json &&
+			chmod 600 /home/agent/.claude/.credentials.json
+		' >/dev/null 2>&1; then
+		echo "cc: no Claude Code credentials in macOS Keychain, or injection failed; sandbox claude may prompt /login" >&2
 	fi
-	printf '%s' "$token" | sbx exec -i "$name" sh -c '
-		mkdir -p /home/agent/.claude &&
-		cat > /home/agent/.claude/.credentials.json &&
-		chmod 600 /home/agent/.claude/.credentials.json
-	' >/dev/null 2>&1 || {
-		echo "cc: failed to inject credentials into sandbox (sandbox may prompt /login)" >&2
-		return 0
-	}
 	return 0
 }
 
@@ -422,14 +421,21 @@ setup_share_symlinks() {
 }
 
 build_sbx_argv() {
-	# Always show the attach form (name-only + claude args) — that's what runs in the hot path.
+	# Show the attach form that actually runs. We use `sbx exec` instead of
+	# `sbx run` because sbx's agent launcher misbehaves with our credential
+	# injection + symlink flow (claude gets SIGKILL'd at startup). `sbx exec`
+	# with -i/-t passes stdio through cleanly.
 	local name
 	name="$(compute_sandbox_name)"
 
-	CC_SBX_ARGV=(sbx run "$name")
+	# -i always (stdin passthrough); -t only if stdin is a real TTY
+	local exec_flags="-i"
+	if [[ -t 0 ]]; then
+		exec_flags="-it"
+	fi
 
+	CC_SBX_ARGV=(sbx exec "$exec_flags" "$name" claude)
 	if [[ ${#CLAUDE_ARGS[@]} -gt 0 ]]; then
-		CC_SBX_ARGV+=(--)
 		CC_SBX_ARGV+=("${CLAUDE_ARGS[@]}")
 	fi
 }
@@ -474,18 +480,12 @@ run_sandbox() {
 	# Step 3: set up sharing symlinks (idempotent)
 	setup_share_symlinks "$name"
 
-	# Step 4: attach via sbx run NAME -- CLAUDE_ARGS (no workspace args)
-	local sbx_pid rc=0
-	"${CC_SBX_ARGV[@]}" &
-	sbx_pid=$!
-
-	# Forward common signals to the child
-	trap 'kill -s INT "$sbx_pid" 2>/dev/null || true' INT
-	trap 'kill -s TERM "$sbx_pid" 2>/dev/null || true' TERM
-
-	wait "$sbx_pid" || rc=$?
-	trap - INT TERM
-	return "$rc"
+	# Step 4: attach to sandbox via sbx exec, running claude in foreground.
+	# Do NOT background-and-wait — sbx exec needs connected stdin/stdout/stderr
+	# to pass through to claude, and the `&` + `wait` pattern can sever stdio.
+	# Signal handling: bash in foreground-exec mode forwards SIGINT/SIGTERM
+	# to the child as long as the child is the only process in the job.
+	"${CC_SBX_ARGV[@]}"
 }
 
 parse_args() {

--- a/bin/cc
+++ b/bin/cc
@@ -3,9 +3,15 @@
 # cc — run Claude Code inside a Docker Sandbox microVM
 # https://github.com/patclarke/claude-docker-sandbox
 
+# shellcheck disable=SC2034
 set -euo pipefail
 
 readonly CC_VERSION="0.1.0"
+
+die() {
+	echo "cc: $*" >&2
+	exit 1
+}
 
 usage() {
 	cat <<'EOF'
@@ -40,16 +46,76 @@ CONFIG:
 EOF
 }
 
-main() {
-	if [[ $# -gt 0 ]]; then
+# Parser state — populated by parse_args
+CC_NAME=""
+CC_NO_SANDBOX=0
+CC_DRY_RUN=0
+CC_DOCTOR=0
+CC_LS=0
+CC_RM=0
+CC_RM_NAME=""
+CC_EXTRA_MOUNTS=()
+CC_SKIP_MOUNTS=()
+CLAUDE_ARGS=()
+
+parse_args() {
+	while [[ $# -gt 0 ]]; do
 		case "$1" in
 		--cc-help | -h)
 			usage
-			return 0
+			exit 0
+			;;
+		--cc-name)
+			[[ $# -ge 2 ]] || die "--cc-name requires a value"
+			CC_NAME="$2"
+			shift 2
+			;;
+		--cc-mount)
+			[[ $# -ge 2 ]] || die "--cc-mount requires a <path>[:ro] value"
+			CC_EXTRA_MOUNTS+=("$2")
+			shift 2
+			;;
+		--cc-no-mount)
+			[[ $# -ge 2 ]] || die "--cc-no-mount requires a path"
+			CC_SKIP_MOUNTS+=("$2")
+			shift 2
+			;;
+		--cc-no-sandbox)
+			CC_NO_SANDBOX=1
+			shift
+			;;
+		--cc-dry-run)
+			CC_DRY_RUN=1
+			shift
+			;;
+		--cc-doctor)
+			CC_DOCTOR=1
+			shift
+			;;
+		--cc-ls)
+			CC_LS=1
+			shift
+			;;
+		--cc-rm)
+			CC_RM=1
+			if [[ $# -ge 2 && "$2" != -* ]]; then
+				CC_RM_NAME="$2"
+				shift 2
+			else
+				shift
+			fi
+			;;
+		*)
+			CLAUDE_ARGS+=("$1")
+			shift
 			;;
 		esac
-	fi
-	echo "cc $CC_VERSION: not yet implemented" >&2
+	done
+}
+
+main() {
+	parse_args "$@"
+	echo "parsed OK. claude_args=(${CLAUDE_ARGS[*]:-})" >&2
 	return 0
 }
 

--- a/bin/cc
+++ b/bin/cc
@@ -363,6 +363,22 @@ build_sbx_argv() {
 	fi
 }
 
+run_sandbox() {
+	build_sbx_argv
+
+	local sbx_pid rc=0
+	"${CC_SBX_ARGV[@]}" &
+	sbx_pid=$!
+
+	# Forward common signals to the child
+	trap 'kill -s INT "$sbx_pid" 2>/dev/null || true' INT
+	trap 'kill -s TERM "$sbx_pid" 2>/dev/null || true' TERM
+
+	wait "$sbx_pid" || rc=$?
+	trap - INT TERM
+	return "$rc"
+}
+
 parse_args() {
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
@@ -459,8 +475,10 @@ main() {
 		return 0
 	fi
 	run_preflight || return 1
-	echo "cc $CC_VERSION: preflight OK (no_sandbox=$CC_NO_SANDBOX)" >&2
-	return 0
+	load_mounts_config
+	resolve_mounts
+	run_sandbox
+	return $?
 }
 
 main "$@"

--- a/bin/cc
+++ b/bin/cc
@@ -65,6 +65,17 @@ preflight_sbx_auth() {
 	return 0
 }
 
+preflight_claude_dir() {
+	local dir="$HOME/.claude"
+	if [[ ! -d "$dir" ]]; then
+		die "$HOME/.claude does not exist. Install or run Claude Code at least once before using cc."
+	fi
+	if [[ ! -w "$dir" ]]; then
+		die "$HOME/.claude is not writable. Session history would be lost. Check ownership/permissions."
+	fi
+	return 0
+}
+
 usage() {
 	cat <<'EOF'
 cc — run Claude Code inside a Docker Sandbox microVM
@@ -183,7 +194,8 @@ main() {
 	preflight_sbx || return 1
 	preflight_docker || return 1
 	preflight_sbx_auth || return 1
-	echo "cc $CC_VERSION: preflight OK through sbx auth" >&2
+	preflight_claude_dir || return 1
+	echo "cc $CC_VERSION: preflight OK" >&2
 	return 0
 }
 

--- a/bin/cc
+++ b/bin/cc
@@ -25,6 +25,39 @@ EOF
 	return 0
 }
 
+preflight_docker() {
+	if docker info >/dev/null 2>&1; then
+		return 0
+	fi
+
+	echo "cc: Docker Desktop is not running. Starting it..." >&2
+	if ! open -a Docker 2>/dev/null; then
+		die "failed to launch Docker Desktop (open -a Docker). Start it manually, then re-run cc."
+	fi
+
+	local waited=0
+	local max_wait=30
+	while ((waited < max_wait)); do
+		if docker info >/dev/null 2>&1; then
+			break
+		fi
+		sleep 1
+		waited=$((waited + 1))
+		printf '.' >&2
+	done
+	echo >&2
+
+	if ! docker info >/dev/null 2>&1; then
+		die "Docker Desktop failed to start within ${max_wait}s. Open it manually, wait for the whale icon to settle, then re-run cc."
+	fi
+
+	if ! docker ps >/dev/null 2>&1; then
+		die "Docker Desktop is responding but the daemon is not ready (docker ps failed). Wait a few seconds and retry."
+	fi
+
+	return 0
+}
+
 usage() {
 	cat <<'EOF'
 cc — run Claude Code inside a Docker Sandbox microVM
@@ -141,7 +174,8 @@ main() {
 		return 0
 	fi
 	preflight_sbx || return 1
-	echo "cc $CC_VERSION: preflight_sbx OK" >&2
+	preflight_docker || return 1
+	echo "cc $CC_VERSION: preflight OK through docker" >&2
 	return 0
 }
 

--- a/bin/cc
+++ b/bin/cc
@@ -438,7 +438,19 @@ build_sbx_argv() {
 		exec_flags="-it"
 	fi
 
-	CC_SBX_ARGV=(sbx exec "$exec_flags" "$name" claude)
+	# Wrap the claude invocation in `env VAR=... claude ...` to propagate
+	# terminal/color variables into the sandbox. sbx exec does not inherit
+	# the host's TERM/COLORTERM/etc, so without this claude defaults to
+	# minimal/no-color output.
+	CC_SBX_ARGV=(
+		sbx exec "$exec_flags" "$name"
+		env
+		"TERM=${TERM:-xterm-256color}"
+		"COLORTERM=${COLORTERM:-truecolor}"
+		"LANG=${LANG:-en_US.UTF-8}"
+		"LC_ALL=${LC_ALL:-en_US.UTF-8}"
+		claude
+	)
 	if [[ ${#CLAUDE_ARGS[@]} -gt 0 ]]; then
 		CC_SBX_ARGV+=("${CLAUDE_ARGS[@]}")
 	fi

--- a/bin/cc
+++ b/bin/cc
@@ -14,84 +14,137 @@ die() {
 }
 
 preflight_sbx() {
-	if ! command -v sbx >/dev/null 2>&1; then
+	command -v sbx >/dev/null 2>&1
+}
+
+preflight_docker() {
+	docker info >/dev/null 2>&1 && docker ps >/dev/null 2>&1
+}
+
+preflight_sbx_auth() {
+	sbx ls >/dev/null 2>&1
+}
+
+preflight_claude_dir() {
+	[[ -d "$HOME/.claude" && -w "$HOME/.claude" ]]
+}
+
+preflight_claude_binary() {
+	command -v claude >/dev/null 2>&1
+}
+
+die_preflight() {
+	case "$1" in
+	sbx)
 		cat >&2 <<'EOF'
 cc: sbx not found on PATH.
     Install:   brew install docker/tap/sbx
     Then run:  sbx login
 EOF
-		return 1
-	fi
-	return 0
+		;;
+	docker)
+		echo "cc: Docker Desktop is not responding. Run 'docker info' to debug." >&2
+		;;
+	sbx_auth)
+		echo "cc: sbx is not authenticated. Run: sbx login" >&2
+		;;
+	claude_dir)
+		echo "cc: $HOME/.claude is missing or not writable. Session history would be lost." >&2
+		;;
+	claude_binary)
+		echo "cc: claude binary not found on PATH." >&2
+		;;
+	esac
+	return 1
 }
 
-preflight_docker() {
+ensure_docker_running() {
 	if docker info >/dev/null 2>&1; then
 		return 0
 	fi
-
 	echo "cc: Docker Desktop is not running. Starting it..." >&2
-	if ! open -a Docker 2>/dev/null; then
-		die "failed to launch Docker Desktop (open -a Docker). Start it manually, then re-run cc."
-	fi
-
+	open -a Docker 2>/dev/null || die "failed to launch Docker Desktop."
 	local waited=0
-	local max_wait=30
-	while ((waited < max_wait)); do
+	while ((waited < 30)); do
 		if docker info >/dev/null 2>&1; then
-			break
+			echo >&2
+			return 0
 		fi
 		sleep 1
 		waited=$((waited + 1))
 		printf '.' >&2
 	done
 	echo >&2
-
-	if ! docker info >/dev/null 2>&1; then
-		die "Docker Desktop failed to start within ${max_wait}s. Open it manually, wait for the whale icon to settle, then re-run cc."
-	fi
-
-	if ! docker ps >/dev/null 2>&1; then
-		die "Docker Desktop is responding but the daemon is not ready (docker ps failed). Wait a few seconds and retry."
-	fi
-
-	return 0
-}
-
-preflight_sbx_auth() {
-	if ! sbx ls >/dev/null 2>&1; then
-		die "sbx is not authenticated. Run: sbx login"
-	fi
-	return 0
-}
-
-preflight_claude_dir() {
-	local dir="$HOME/.claude"
-	if [[ ! -d "$dir" ]]; then
-		die "$HOME/.claude does not exist. Install or run Claude Code at least once before using cc."
-	fi
-	if [[ ! -w "$dir" ]]; then
-		die "$HOME/.claude is not writable. Session history would be lost. Check ownership/permissions."
-	fi
-	return 0
-}
-
-preflight_claude_binary() {
-	if ! command -v claude >/dev/null 2>&1; then
-		die "claude binary not found on PATH. Install Claude Code and ensure it is on PATH."
-	fi
-	return 0
+	die "Docker Desktop failed to start within 30s."
 }
 
 run_preflight() {
 	if [[ $CC_NO_SANDBOX -eq 1 ]]; then
-		preflight_claude_binary || return 1
+		preflight_claude_binary || die_preflight claude_binary
 		return 0
 	fi
-	preflight_sbx || return 1
-	preflight_docker || return 1
-	preflight_sbx_auth || return 1
-	preflight_claude_dir || return 1
+	preflight_sbx || die_preflight sbx
+	ensure_docker_running
+	preflight_docker || die_preflight docker
+	preflight_sbx_auth || die_preflight sbx_auth
+	preflight_claude_dir || die_preflight claude_dir
+	return 0
+}
+
+print_check() {
+	local state="$1" label="$2"
+	case "$state" in
+	OK) printf '  \033[32mOK\033[0m    %s\n' "$label" ;;
+	WARN) printf '  \033[33mWARN\033[0m  %s\n' "$label" ;;
+	FAIL) printf '  \033[31mFAIL\033[0m  %s\n' "$label" ;;
+	esac
+}
+
+run_doctor() {
+	local fails=0
+	echo "cc doctor"
+	echo
+
+	if preflight_sbx; then
+		print_check OK "sbx installed"
+	else
+		print_check FAIL "sbx installed    (brew install docker/tap/sbx)"
+		fails=$((fails + 1))
+	fi
+
+	if preflight_docker; then
+		print_check OK "Docker Desktop running"
+	else
+		print_check FAIL "Docker Desktop running    (open -a Docker)"
+		fails=$((fails + 1))
+	fi
+
+	if preflight_sbx_auth; then
+		print_check OK "sbx authenticated"
+	else
+		print_check FAIL "sbx authenticated    (sbx login)"
+		fails=$((fails + 1))
+	fi
+
+	if preflight_claude_dir; then
+		print_check OK "$HOME/.claude is writable"
+	else
+		print_check FAIL "$HOME/.claude is writable    (check permissions)"
+		fails=$((fails + 1))
+	fi
+
+	if preflight_claude_binary; then
+		print_check OK "claude installed on host (escape hatch available)"
+	else
+		print_check WARN "claude not on host    (--cc-no-sandbox will fail)"
+	fi
+
+	echo
+	if ((fails > 0)); then
+		echo "$fails check(s) failed."
+		return 1
+	fi
+	echo "All checks passed."
 	return 0
 }
 
@@ -206,6 +259,10 @@ dry_run_output() {
 
 main() {
 	parse_args "$@"
+	if [[ $CC_DOCTOR -eq 1 ]]; then
+		run_doctor
+		return $?
+	fi
 	if [[ $CC_DRY_RUN -eq 1 ]]; then
 		dry_run_output
 		return 0

--- a/bin/cc
+++ b/bin/cc
@@ -605,6 +605,12 @@ main() {
 		return 0
 	fi
 	run_preflight || return 1
+
+	if [[ $CC_NO_SANDBOX -eq 1 ]]; then
+		# Escape hatch: bypass sbx entirely, exec host claude directly.
+		exec claude "${CLAUDE_ARGS[@]+"${CLAUDE_ARGS[@]}"}"
+	fi
+
 	load_mounts_config
 	resolve_mounts
 	run_sandbox

--- a/bin/cc
+++ b/bin/cc
@@ -102,6 +102,14 @@ print_check() {
 	esac
 }
 
+run_ls() {
+	preflight_sbx || die_preflight sbx
+	ensure_docker_running
+	preflight_sbx_auth || die_preflight sbx_auth
+	echo "# active sbx sandboxes"
+	sbx ls
+}
+
 run_doctor() {
 	local fails=0
 	echo "cc doctor"
@@ -598,6 +606,10 @@ main() {
 	parse_args "$@"
 	if [[ $CC_DOCTOR -eq 1 ]]; then
 		run_doctor
+		return $?
+	fi
+	if [[ $CC_LS -eq 1 ]]; then
+		run_ls
 		return $?
 	fi
 	if [[ $CC_DRY_RUN -eq 1 ]]; then


### PR DESCRIPTION
## Summary

Implements `bin/cc`, a bash wrapper that runs Claude Code inside a [Docker Sandbox](https://docs.docker.com/ai/sandboxes/) microVM with auto-authentication and session sharing.

## What it does

- **Mount strategy:** mounts `$PWD` RW as the primary workspace, plus a configurable allow-list of host paths (`~/Desktop`, `~/Downloads`, `~/.claude/projects` RW, `~/.claude/plugins` RO, `~/.claude/skills` RO, credentials RO).
- **Auto-auth:** extracts the host's Claude Code OAuth token from macOS Keychain (`security find-generic-password -s "Claude Code-credentials"`) and injects it into the sandbox's `/home/agent/.claude/.credentials.json` on every invocation. No `/login` required.
- **Session sharing:** symlinks `/home/agent/.claude/projects`, `plugins`, and `skills` inside the sandbox to the host's mounted paths, so conversations, plugins, and skills are visible in both host and sandbox claude.
- **Cwd-ancestor mount stripping:** automatically removes `~/workspace` from the mount list when cwd is under it, avoiding sbx's container-start hook failures.
- **Flags:** `--cc-dry-run`, `--cc-doctor`, `--cc-ls`, `--cc-rm`, `--cc-no-sandbox`, `--cc-name`, `--cc-mount`, `--cc-no-mount`, `--cc-help`.
- **Preflight:** checks `sbx`, Docker (auto-starts with 30s timeout), `sbx` auth, `~/.claude` writability.
- **TTY-aware:** propagates TERM/COLORTERM/LANG/LC_ALL into the sandbox so claude renders in color.

## Key discoveries during implementation

The original design had several wrong assumptions about sbx that only surfaced during live testing:

1. **sbx remaps the primary workspace** to `/home/agent/workspace` inside the sandbox. Primary cwd is NOT preserved at its absolute host path. Additional workspaces ARE preserved.
2. **Nested mounts fail** at container-start when cwd is under an RO-mounted ancestor (container hook tries to write to cwd's parent dir). Fixed by always stripping cwd-ancestor mounts.
3. **macOS Keychain stores Claude Code credentials** in a 472-byte JSON blob that is byte-for-byte compatible with Linux Claude Code's `.credentials.json` format. We extract non-interactively and inject via `sbx exec -i`.
4. **sbx rapid-call race:** running multiple `sbx` subcommands back-to-back leaves the daemon in a state where the next interactive exec is SIGKILL'd at startup. Worked around with a 1-second `sleep` before the final attach. Worth reporting upstream.
5. **`sbx run` agent launcher misbehaves** with our credential injection + symlink flow (SIGKILL). `sbx exec` is used instead as the attach mechanism.
6. **`bash -x` leaks secrets** when the token lives in a shell variable. `inject_credentials` pipes directly from `security` to `sbx exec -i` without any intermediate variable.
7. **sbx's claude image has `"defaultMode": "bypassPermissions"` baked in.** No need to pass `--dangerously-skip-permissions`.

Full write-up of all 6+ lessons is in `CLAUDE.md`.

## Structure

31 commits organized as:

- **Scaffolding and parser:** `bin/cc` skeleton, `--cc-help`, argument parser, `--cc-dry-run` (Tasks 1-4)
- **Preflight and doctor:** `sbx`, Docker (with auto-start), auth, `~/.claude` checks, `--cc-doctor` reporter (Tasks 5-10)
- **Mount pipeline:** `~/.config/cc/mounts.conf`, overrides, missing-path filter, cwd-ancestor stripping (Tasks 11-14, later revised)
- **Build sbx argv:** deterministic sandbox naming, dry-run polish (Tasks 15-17)
- **Exec phase:** create → inject creds → symlink → `sbx exec` attach (Task 18, heavily revised)
- **Subcommands:** `--cc-no-sandbox`, `--cc-ls`, `--cc-rm` (Tasks 20-22)
- **Docs:** README install instructions, roadmap, CLAUDE.md lessons (Task 23)

Six `fix:` commits capture the iteration as live testing surfaced the above gotchas.

## Test plan

Verified end-to-end during implementation:

- [x] `cc --cc-dry-run` renders full mount plan with cwd-ancestor stripped, sandbox name derived, correct `sbx exec` COMMAND line
- [x] `cc --cc-doctor` reports OK status for all preflight checks + displays resolved mount plan
- [x] `cc --cc-ls` lists sandboxes
- [x] `cc --cc-rm <nonexistent>` reports "no sandbox named" and exits 1
- [x] `cc --cc-help` shows usage with version
- [x] `cc -p "..."` creates sandbox, injects credentials, sets up symlinks, runs claude, prints response, exits 0
- [x] `cc` (interactive) launches claude's welcome screen with colors, session state, and auth intact
- [x] Reconnect (second `cc` invocation in same dir) reuses the existing sandbox
- [x] Session files written inside sandbox are visible on host via symlink
- [x] `shellcheck bin/cc` and `shfmt -d bin/cc` clean

Not yet validated:

- [ ] `cc --cc-rm` actually removing with `y` confirmation (interactive, controller did not run to avoid side effects during testing)
- [ ] `cc --cc-no-sandbox` exec-ing host claude (same reason)
- [ ] `cc --cc-mount` and `cc --cc-no-mount` one-off overrides via real sandbox (dry-run verified but no exec)
- [ ] Running from a directory outside `~/workspace`
- [ ] Linux / Windows support

## Known limitations

- macOS only for now. Linux may work but is untested.
- The 1-second `sleep` before the final attach is a workaround for an upstream sbx race. Needs a real issue filed.
- Plugin installation from inside a sandbox session does NOT persist (plugins are mounted RO). Install from host claude.
- User-level `~/.claude/CLAUDE.md` is not available inside the sandbox (sbx rejects non-directory additional workspaces). Project-level `CLAUDE.md` in the cwd mount still applies.
- First sandbox creation pulls the `docker/sandbox-templates:claude-code-docker` image (~GB). Subsequent sandboxes reuse it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)