### PR TITLE
refactor: rename cc to cdc (Closes #10)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code when working in this repository.
 
 ## Project overview
 
-`claude-docker-sandbox` ships a single bash script — `cc` — that wraps
+`claude-docker-container` ships a single bash script — `cdc` — that wraps
 Claude Code invocations in a [Docker Sandbox](https://docs.docker.com/ai/sandboxes/)
 microVM, so unsupervised agents have a bounded blast radius instead of an
 unbounded one. See [`README.md`](README.md) for user-facing documentation.
@@ -12,7 +12,7 @@ unbounded one. See [`README.md`](README.md) for user-facing documentation.
 The implementation is intentionally small: one shell script, one config file,
 one README. Resist the urge to grow it into a framework.
 
-**Auth flow:** `cc` extracts the Claude Code token from the macOS Keychain
+**Auth flow:** `cdc` extracts the Claude Code token from the macOS Keychain
 (`security find-generic-password -s 'Claude Code-credentials'`) and injects it
 into the sandbox on every invocation via `sbx exec`. Claude inside the sandbox
 runs as user `agent` and looks for credentials at
@@ -22,7 +22,7 @@ runs as user `agent` and looks for credentials at
 
 ```
 .
-├── bin/cc                  the wrapper script
+├── bin/cdc                 the wrapper script
 ├── README.md               user-facing documentation
 ├── CLAUDE.md               this file
 ├── LICENSE                 MIT
@@ -37,24 +37,24 @@ not try to reconstruct it from git history.
 
 ## How to think about the script
 
-`cc` runs in three phases on every invocation. When modifying it, keep these
+`cdc` runs in three phases on every invocation. When modifying it, keep these
 phases distinct — do not interleave parsing with planning or planning with
 execution.
 
-1. **Parse.** Walk `$@` once. Any arg starting with `--cc-` is a wrapper flag
+1. **Parse.** Walk `$@` once. Any arg starting with `--cdc-` is a wrapper flag
    and gets consumed; everything else goes into a `CLAUDE_ARGS` array to be
    forwarded verbatim to `claude` inside the sandbox.
-2. **Plan.** Run preflight checks. Read `~/.config/cc/mounts.conf` (create it
-   from defaults if missing). Apply `--cc-mount` additions and `--cc-no-mount`
+2. **Plan.** Run preflight checks. Read `~/.config/cdc/mounts.conf` (create it
+   from defaults if missing). Apply `--cdc-mount` additions and `--cdc-no-mount`
    removals. Strip ancestor mounts. Compute a deterministic sandbox name from
    cwd. Build the final `sbx` argv.
 3. **Exec.** If the named sandbox doesn't exist, create it with
    `sbx create claude <primary> <mounts>`. Then inject credentials via
    `sbx exec -i`. Then create sharing symlinks via `sbx exec`. Finally attach
    with `sbx exec -it <name> env ... claude <claude-args>`, replacing the
-   cc process via `exec`. Propagate sbx's exit code.
+   cdc process via `exec`. Propagate sbx's exit code.
 
-The `--cc-dry-run`, `--cc-doctor`, and `--cc-no-sandbox` flags short-circuit
+The `--cdc-dry-run`, `--cdc-doctor`, and `--cdc-no-sandbox` flags short-circuit
 the exec phase in different ways; they still run parse and the relevant parts
 of plan.
 
@@ -64,14 +64,14 @@ The original design spec had three "unknowns" that live testing resolved:
 
 1. **sbx arg-passing syntax:** `sbx run <sandbox> -- <claude-args>` works, but
    `sbx run` itself misbehaves with our credential + symlink flow and sends
-   SIGKILL to claude at startup. cc uses `sbx exec` as the attach mechanism
+   SIGKILL to claude at startup. cdc uses `sbx exec` as the attach mechanism
    instead, losing some of sbx's agent-launcher niceties but gaining reliable
    exec.
 
 2. **Nested mounts:** sbx accepts overlapping mounts at the parse level but
    its container-start hooks fail when the cwd's parent directory is under an
    RO mount (the hook tries to write a CLAUDE.md one level above cwd and hits
-   a read-only filesystem). cc strips any mount that is an ancestor of the
+   a read-only filesystem). cdc strips any mount that is an ancestor of the
    current cwd from the resolved mount list as a general rule.
 
 3. **`~/.claude` cross-visibility:** inside the sandbox, `HOME=/home/agent`
@@ -92,7 +92,7 @@ Additional runtime surprises found during implementation:
    explicitly set the working directory, claude starts in an empty dir and
    reports "no files found" no matter what is in the host path. Fix:
    `sbx exec -w <host-path>` when attaching so claude starts in the real
-   mounted location. This is `bin/cc`'s `build_sbx_argv` behavior — see
+   mounted location. This is `bin/cdc`'s `build_sbx_argv` behavior — see
    the `-w "$pwd_abs"` argument. Reported by @wmaykut as issue #6.
 
 5. **sbx rapid-call race:** Running several sbx subcommands back-to-back
@@ -116,7 +116,7 @@ Key sbx facts that govern the implementation:
 
 - **Primary workspace path:** sbx mounts the primary workspace at its
   absolute host path via virtiofs bind mount, same as additional mounts.
-  It does NOT symlink `/home/agent/workspace` to the mount. `cc` sets the
+  It does NOT symlink `/home/agent/workspace` to the mount. `cdc` sets the
   initial working directory with `sbx exec -w` to land the agent at the
   real host path.
 - **sbx has no env var flag:** `sbx create` only supports `--branch`,
@@ -125,7 +125,7 @@ Key sbx facts that govern the implementation:
 - **Bypass mode is the default:** sbx's claude image has
   `"defaultMode": "bypassPermissions"` pre-configured in
   `/home/agent/.claude/settings.json`. Do not add any bypass flag as a
-  default in `cc`.
+  default in `cdc`.
 - **Create vs. attach:** Passing workspace paths to an existing sandbox errors
   with "sandbox X already exists and can't be given new workspaces". The
   correct flow: `sbx create claude <primary> <mounts>` once, then
@@ -209,18 +209,18 @@ Conventional format:
 There is **no automated test suite.** This is a bash wrapper around a CLI on
 a specific developer machine; the validation model is a manual checklist.
 
-When changing `bin/cc`, walk through the full validation matrix before opening
+When changing `bin/cdc`, walk through the full validation matrix before opening
 a PR:
 
-1. **Preflight matrix.** Run `cc --cc-doctor` with each dependency
+1. **Preflight matrix.** Run `cdc --cdc-doctor` with each dependency
    intentionally broken, confirm the right FAIL lines appear with actionable
    remedies. Restore state.
 2. **Core invocation matrix.** From a real project under `~/workspace`,
-   exercise `cc`, `cc -c`, `cc --cc-name experiment-1`, `cc --cc-no-sandbox`,
-   `cc --cc-dry-run`, `cc --cc-ls`, `cc --cc-rm`.
-3. **Mount override matrix.** Confirm `--cc-mount` additions and
-   `--cc-no-mount` removals appear correctly in `--cc-dry-run` output.
-4. **Worktree sanity.** Run `cc` from a `.worktrees/feat-foo` directory under
+   exercise `cdc`, `cdc -c`, `cdc --cdc-name experiment-1`, `cdc --cdc-no-sandbox`,
+   `cdc --cdc-dry-run`, `cdc --cdc-ls`, `cdc --cdc-rm`.
+3. **Mount override matrix.** Confirm `--cdc-mount` additions and
+   `--cdc-no-mount` removals appear correctly in `--cdc-dry-run` output.
+4. **Worktree sanity.** Run `cdc` from a `.worktrees/feat-foo` directory under
    another repo and confirm the primary mount is the worktree path, not the
    main checkout.
 5. **Failure spot checks.** Quit Docker Desktop mid-session, Ctrl-C during the
@@ -229,8 +229,8 @@ a PR:
 Shell lint:
 
 ```bash
-shellcheck bin/cc
-shfmt -d bin/cc
+shellcheck bin/cdc
+shfmt -d bin/cdc
 ```
 
 Install if missing: `brew install shellcheck shfmt`.
@@ -249,11 +249,11 @@ This repo intentionally does one thing. **Do not** add:
   would dwarf the script itself.
 
 If a change you're considering doesn't fit in a `feat:` or `fix:` commit
-against `bin/cc`, `README.md`, `CLAUDE.md`, or `.gitignore`, it probably
+against `bin/cdc`, `README.md`, `CLAUDE.md`, or `.gitignore`, it probably
 doesn't belong in this repo.
 
 **Plugin and skill installation:** plugins and skills must be installed on the
-host (`claude` without `cc`), not inside a sandbox. The sandbox mounts
+host (`claude` without `cdc`), not inside a sandbox. The sandbox mounts
 `~/.claude/plugins` and `~/.claude/skills` read-only to prevent a runaway
 sandbox from injecting malicious code into host-side executable paths. Any
 plugin installed inside a sandbox is lost when the session ends.
@@ -263,4 +263,4 @@ plugin installed inside a sandbox is lost when the session ends.
   `/Users/<you>/.claude/plugins` and `/Users/<you>/.claude/skills`. A plugin
   install from inside the sandbox will either fail or write to a scratch
   location that vanishes when the sandbox is removed. Install plugins from
-  a host claude session instead (plain `claude`, not via `cc`).
+  a host claude session instead (plain `claude`, not via `cdc`).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# claude-docker-sandbox
+# claude-docker-container
 
-`cc` — run [Claude Code](https://claude.com/claude-code) in dangerous mode
+`cdc` — run [Claude Code](https://claude.com/claude-code) in dangerous mode
 without losing sleep.
 
 ## The pitch
@@ -26,11 +26,11 @@ agent goes off the rails and `aws s3 rb` the wrong bucket, or force-pushes
 `main`, I have a bad week. I wanted dangerous mode's velocity *and* a hard
 guarantee that certain kinds of damage were impossible.
 
-That's what `cc` is.
+That's what `cdc` is.
 
 ## What it is
 
-`cc` is a bash wrapper around [Docker Sandboxes](https://docs.docker.com/ai/sandboxes/)
+`cdc` is a bash wrapper around [Docker Sandboxes](https://docs.docker.com/ai/sandboxes/)
 that runs Claude Code inside an isolated microVM. **Inside the sandbox,
 `--dangerously-skip-permissions` is always on. You can't turn it off — that's
 the whole point.** The sandbox is the blast radius, not the prompt.
@@ -40,28 +40,28 @@ paths you've explicitly shared with it. It has its own filesystem, its own
 Docker daemon, its own network namespace, its own kernel. To the agent running
 inside, the rest of your Mac might as well not exist.
 
-On top of sbx, `cc` adds the bits you'd otherwise have to do by hand:
+On top of sbx, `cdc` adds the bits you'd otherwise have to do by hand:
 
 - Automatic credential injection from your macOS Keychain, so Claude is
   logged in inside the sandbox without running `/login`
-- Session history sharing between host and sandbox, so `cc -c` resumes a
+- Session history sharing between host and sandbox, so `cdc -c` resumes a
   conversation you had with plain `claude` and vice versa
 - Plugin and skill sharing (read-only) so your configured workflows work
   identically inside and outside the sandbox
 - Smart mount policy that handles the nested-mount case when your project is
   under `~/workspace`
-- Preflight checks, Docker auto-start, a `--cc-doctor` health check, and a
+- Preflight checks, Docker auto-start, a `--cdc-doctor` health check, and a
   clean escape hatch when any of this breaks
 
 You keep typing the same `claude …` commands you're used to. You just type
-`cc` instead.
+`cdc` instead.
 
-## What `cc` guarantees
+## What `cdc` guarantees
 
 Inside the sandbox, Claude runs with `--dangerously-skip-permissions` enabled.
 You can't turn it off. (You can bypass the sandbox entirely with
-`cc --cc-no-sandbox`, but at that point you're back to plain `claude` with no
-isolation. `cc` also doesn't shadow `claude` — your regular `claude` binary
+`cdc --cdc-no-sandbox`, but at that point you're back to plain `claude` with no
+isolation. `cdc` also doesn't shadow `claude` — your regular `claude` binary
 is always on `PATH` unchanged, as an escape hatch.)
 
 With the default mount policy, these things are **physically impossible**:
@@ -82,7 +82,7 @@ With the default mount policy, these things are **physically impossible**:
   swap in an attacker's token or corrupt your keys.
 - **Claude cannot access your macOS Keychain directly.** Keychain is a macOS
   API, and the sandbox is Linux. It only sees the specific credential that
-  `cc` injects (the Claude Code OAuth token) — not anything else stored
+  `cdc` injects (the Claude Code OAuth token) — not anything else stored
   there.
 - **Claude cannot escape the sandbox.** sbx uses microVM (hypervisor-level)
   isolation, not just containers. Breaking out requires a VM escape.
@@ -92,9 +92,9 @@ If a prompt injection from some document you asked Claude to read says
 `~/.claude/plugins/superpowers/core.md`" — nothing happens. That directory
 is read-only inside the sandbox.
 
-## What `cc` does NOT guarantee
+## What `cdc` does NOT guarantee
 
-`cc` is filesystem-level isolation. It's very good at that. Some things it
+`cdc` is filesystem-level isolation. It's very good at that. Some things it
 does not and cannot do, which you should understand clearly:
 
 ### Network-level isolation is out of scope
@@ -139,12 +139,12 @@ back it up if you care.
 
 ### Your current working directory is fully writable
 
-Obvious but worth naming: whatever is in `$PWD` when you run `cc`, the
+Obvious but worth naming: whatever is in `$PWD` when you run `cdc`, the
 sandbox can read and write. If your project contains `.env` files with
 secrets, a deploy key, or other sensitive files, the sandbox sees them.
 Don't commit secrets into your project and also don't mount them into it.
 
-### `cc --cc-no-sandbox` bypasses everything
+### `cdc --cdc-no-sandbox` bypasses everything
 
 The escape hatch runs plain `claude` on your host with the forwarded args.
 No sandbox, no isolation. It's there for when sbx/Docker is broken and you
@@ -168,12 +168,12 @@ injection can make it happen — the API returns AccessDenied, end of story.
   (1 hour is typical). Any credential the sandbox sees expires fast.
 - [`granted/assume`](https://docs.commonfate.io/granted/) and
   [`aws-vault`](https://github.com/99designs/aws-vault) both let you get
-  temporary session credentials for a specific role. Use them to run `cc`
+  temporary session credentials for a specific role. Use them to run `cdc`
   inside a shell that has only the scoped role in its `AWS_PROFILE`.
 - For read-only work: create a dedicated IAM role with just `ReadOnlyAccess`
-  (AWS-managed policy). Use *that* role's profile when you run `cc`.
+  (AWS-managed policy). Use *that* role's profile when you run `cdc`.
 - If you're not doing AWS work in a particular session, drop the mount:
-  `cc --cc-no-mount ~/.aws`. The sandbox won't see AWS credentials at all.
+  `cdc --cdc-no-mount ~/.aws`. The sandbox won't see AWS credentials at all.
 
 ### GitHub
 
@@ -187,7 +187,7 @@ specific permissions. For "the agent can open PRs but not delete repos":
 3. Grant only: `Contents: Read`, `Pull requests: Write`, `Issues: Write`
 4. Do NOT grant: `Administration`, `Delete repo`, `Workflows`, `Secrets`
 5. Generate the token, then authenticate a separate `gh` profile
-6. Swap the gh profile before running `cc`
+6. Swap the gh profile before running `cdc`
 
 With that token mounted, a compromised agent literally cannot call
 `DELETE /repos/{owner}/{repo}`. GitHub's API rejects the request.
@@ -219,7 +219,7 @@ You'll need:
 
 - A Mac running macOS 13 or newer
 - A Claude account — sign up at [claude.ai](https://claude.ai) if you
-  don't have one (the free tier is enough to get started; `cc` works with
+  don't have one (the free tier is enough to get started; `cdc` works with
   any Claude Code tier)
 - About 10 GB of free disk space (most of it is Docker Desktop and the
   sandbox image)
@@ -250,7 +250,7 @@ again to confirm.
 ### Step 2: install Docker Desktop
 
 Docker Desktop provides the virtualization layer that sandboxes run
-inside. You need it installed and *running* before `cc` can do anything.
+inside. You need it installed and *running* before `cdc` can do anything.
 
 ```bash
 brew install --cask docker
@@ -273,14 +273,14 @@ docker info >/dev/null 2>&1 && echo "✅ Docker is running" || echo "❌ Docker 
 
 If you see `❌`, open Docker Desktop and wait for the menu-bar whale to
 settle, then try again. You can quit Docker Desktop anytime you're not
-using `cc`; `cc` will auto-start it on the next run if needed.
+using `cdc`; `cdc` will auto-start it on the next run if needed.
 
 ### Step 3: install Claude Code and log in
 
 [Claude Code](https://claude.com/claude-code) is Anthropic's official
-command-line interface for Claude. `cc` runs it inside the sandbox, but
+command-line interface for Claude. `cdc` runs it inside the sandbox, but
 it also needs to be installed on your host so it can authenticate once
-and so the escape hatch (`cc --cc-no-sandbox`) works.
+and so the escape hatch (`cdc --cdc-no-sandbox`) works.
 
 Follow the install instructions on [claude.com/claude-code](https://claude.com/claude-code)
 for your platform. For macOS, the installer puts `claude` on your PATH.
@@ -295,7 +295,7 @@ Inside Claude, press `/` and choose `/login` (or type it). A browser
 window opens — sign in with your Claude account. Come back to the
 terminal, and Claude will confirm you're logged in. Type `/quit` to exit.
 
-This one-time login stores an OAuth token in your Mac's Keychain. `cc`
+This one-time login stores an OAuth token in your Mac's Keychain. `cdc`
 will read that token (with your permission) and pass it into the sandbox
 so you don't have to log in again later.
 
@@ -343,16 +343,16 @@ sbx ls
 You should see a "No sandboxes found" message (that's the success case —
 you don't have any sandboxes yet).
 
-### Step 5: install `cc`
+### Step 5: install `cdc`
 
-`cc` itself is a single bash script. Drop it into `~/bin` and put that
+`cdc` itself is a single bash script. Drop it into `~/bin` and put that
 directory on your PATH:
 
 ```bash
-# Create ~/bin and download cc into it
+# Create ~/bin and download cdc into it
 mkdir -p ~/bin
-curl -fsSL https://raw.githubusercontent.com/patclarke/claude-docker-sandbox/main/bin/cc -o ~/bin/cc
-chmod +x ~/bin/cc
+curl -fsSL https://raw.githubusercontent.com/patclarke/claude-docker-container/main/bin/cdc -o ~/bin/cdc
+chmod +x ~/bin/cdc
 
 # Make sure ~/bin is on PATH (for zsh, which is the macOS default)
 grep -q 'export PATH="$HOME/bin:$PATH"' ~/.zshrc || \
@@ -368,24 +368,24 @@ in the line above.
 **Verify:**
 
 ```bash
-which cc
+which cdc
 ```
 
-Should print: `/Users/<your-username>/bin/cc`
+Should print: `/Users/<your-username>/bin/cdc`
 
 ### Step 6: final health check
 
-`cc` has a built-in health check that runs through everything from Steps
+`cdc` has a built-in health check that runs through everything from Steps
 2–4 and reports the status:
 
 ```bash
-cc --cc-doctor
+cdc --cdc-doctor
 ```
 
 You should see five green `OK` lines:
 
 ```
-cc doctor
+cdc doctor
 
   OK    sbx installed
   OK    Docker Desktop running
@@ -393,7 +393,7 @@ cc doctor
   OK    /Users/you/.claude is writable
   OK    claude installed on host (escape hatch available)
 
-Mount plan (from /Users/you/.config/cc/mounts.conf):
+Mount plan (from /Users/you/.config/cdc/mounts.conf):
   RO   /Users/you/Desktop
   RO   /Users/you/Downloads
   RW   /Users/you/.claude/projects
@@ -403,8 +403,8 @@ All checks passed.
 ```
 
 If anything is `FAIL`, the doctor prints exactly which step you need to
-revisit. The first time you run `cc --cc-doctor`, it creates
-`~/.config/cc/mounts.conf` with the default mount policy.
+revisit. The first time you run `cdc --cdc-doctor`, it creates
+`~/.config/cdc/mounts.conf` with the default mount policy.
 
 **You're done.** Jump to [Quick start](#quick-start) to actually run
 something.
@@ -427,27 +427,27 @@ you can create one for free at
 [hub.docker.com/signup](https://hub.docker.com/signup). sbx needs this to
 authenticate you; there's no cost.
 
-**`cc --cc-doctor` says "claude installed on host" is WARN, not FAIL** —
+**`cdc --cdc-doctor` says "claude installed on host" is WARN, not FAIL** —
 that just means the host `claude` binary is missing, so the
-`--cc-no-sandbox` escape hatch won't work. `cc` itself still works fine;
+`--cdc-no-sandbox` escape hatch won't work. `cdc` itself still works fine;
 it uses the claude that lives inside the sandbox. Fix it by revisiting
 Step 3 if you want the escape hatch.
 
 **Anything else** — open an issue at
-[github.com/patclarke/claude-docker-sandbox/issues](https://github.com/patclarke/claude-docker-sandbox/issues)
-with the output of `cc --cc-doctor` and I'll take a look.
+[github.com/patclarke/claude-docker-container/issues](https://github.com/patclarke/claude-docker-container/issues)
+with the output of `cdc --cdc-doctor` and I'll take a look.
 
 ## Quick start
 
 ```bash
 cd ~/workspace/my-project
-caffeinate -dims cc --remote-control --chrome -c
+caffeinate -dims cdc --remote-control --chrome -c
 ```
 
 Breakdown:
 
 - `caffeinate -dims` — keep your Mac awake while the session runs
-- `cc` — launch Claude Code inside a sandbox for this directory
+- `cdc` — launch Claude Code inside a sandbox for this directory
 - `--remote-control --chrome -c` — regular Claude Code flags, passed through
   to the agent inside the sandbox
 
@@ -463,17 +463,17 @@ to your session history and plugins.
 
 ## How it works
 
-On every invocation, `cc` does this:
+On every invocation, `cdc` does this:
 
 1. **Preflight.** Check that `sbx` is installed, Docker Desktop is running
    (auto-start if not), `sbx` is authenticated, and `~/.claude` is writable.
-2. **Plan.** Load mounts from `~/.config/cc/mounts.conf`, apply `--cc-mount`
-   and `--cc-no-mount` overrides, drop any mount whose path is missing, and
+2. **Plan.** Load mounts from `~/.config/cdc/mounts.conf`, apply `--cdc-mount`
+   and `--cdc-no-mount` overrides, drop any mount whose path is missing, and
    strip any mount that's an ancestor of your current working directory
    (prevents sbx's container-start hook from failing on nested mounts).
 3. **Create.** If no sandbox exists for this cwd yet, run `sbx create claude`
    with the resolved mount list and a deterministic name derived from the
-   directory path. The sandbox persists — subsequent `cc` invocations in the
+   directory path. The sandbox persists — subsequent `cdc` invocations in the
    same directory reconnect to it.
 4. **Inject credentials.** Pipe the host's Claude Code OAuth token from
    macOS Keychain (via `security find-generic-password`) directly into the
@@ -489,14 +489,14 @@ On every invocation, `cc` does this:
    terminal's color capability, authenticated, with access to your session
    history.
 
-The script is ~660 lines of bash at `bin/cc`. Read it — it's meant to be
+The script is ~680 lines of bash at `bin/cdc`. Read it — it's meant to be
 understood.
 
 ## Configuration
 
-### Default `~/.config/cc/mounts.conf`
+### Default `~/.config/cdc/mounts.conf`
 
-Written automatically the first time you run `cc`:
+Written automatically the first time you run `cdc`:
 
 ```
 # Format:  <path>[:ro]
@@ -504,7 +504,7 @@ Written automatically the first time you run `cc`:
 # Non-existent paths are skipped silently at launch.
 
 # Cross-project reference (read-only view of sibling repos).
-# cc automatically strips any mount that's an ancestor of $PWD, so
+# cdc automatically strips any mount that's an ancestor of $PWD, so
 # this is safe even when cwd is inside ~/workspace.
 ~/workspace:ro
 
@@ -546,78 +546,78 @@ user-level `~/.claude/CLAUDE.md` is not shared. Project-level `CLAUDE.md` in
 
 ### Customizing
 
-Permanent changes: edit `~/.config/cc/mounts.conf`. One line per mount,
+Permanent changes: edit `~/.config/cdc/mounts.conf`. One line per mount,
 `#` for comments, `~` expansion supported, `:ro` suffix for read-only.
 Non-existent paths are skipped silently.
 
 ```bash
 # Add a permanent mount
-echo '~/Notes:ro' >> ~/.config/cc/mounts.conf
+echo '~/Notes:ro' >> ~/.config/cdc/mounts.conf
 
 # Remove a permanent mount — delete or comment out the line
 ```
 
-One-off changes: use `--cc-mount` or `--cc-no-mount` on a single invocation.
+One-off changes: use `--cdc-mount` or `--cdc-no-mount` on a single invocation.
 
 ## Reference
 
 ### Flags
 
-`cc` reserves only flags with a `--cc-*` prefix. Everything else passes
+`cdc` reserves only flags with a `--cdc-*` prefix. Everything else passes
 through to `claude` untouched.
 
-| Flag                      | Purpose                                                        |
-|---------------------------|----------------------------------------------------------------|
-| `--cc-name <label>`       | Named sandbox (for running parallel sessions in the same dir)  |
-| `--cc-mount <path>[:ro]`  | Add an extra mount for this invocation (repeatable)            |
-| `--cc-no-mount <path>`    | Skip a config-file mount for this invocation (repeatable)      |
-| `--cc-no-sandbox`         | Escape hatch — exec host `claude` directly                     |
-| `--cc-rm [name]`          | Remove the sandbox for cwd (or the named one), with a prompt   |
-| `--cc-ls`                 | List active sandboxes                                          |
-| `--cc-dry-run`            | Print the resolved `sbx` command for this cwd, don't exec      |
-| `--cc-doctor`             | Run preflight checks and show the resolved mount list          |
-| `--cc-help`, `-h`         | Usage                                                          |
+| Flag                       | Purpose                                                        |
+|----------------------------|----------------------------------------------------------------|
+| `--cdc-name <label>`       | Named sandbox (for running parallel sessions in the same dir)  |
+| `--cdc-mount <path>[:ro]`  | Add an extra mount for this invocation (repeatable)            |
+| `--cdc-no-mount <path>`    | Skip a config-file mount for this invocation (repeatable)      |
+| `--cdc-no-sandbox`         | Escape hatch — exec host `claude` directly                     |
+| `--cdc-rm [name]`          | Remove the sandbox for cwd (or the named one), with a prompt   |
+| `--cdc-ls`                 | List active sandboxes                                          |
+| `--cdc-dry-run`            | Print the resolved `sbx` command for this cwd, don't exec      |
+| `--cdc-doctor`             | Run preflight checks and show the resolved mount list          |
+| `--cdc-help`, `-h`         | Usage                                                          |
 
 ### Common invocations
 
 ```bash
 # Fresh session in this directory
-cc
+cdc
 
 # Resume the most recent session in this directory
-cc -c
+cdc -c
 
 # Forward arbitrary Claude Code flags
-cc --remote-control --chrome -c
+cdc --remote-control --chrome -c
 
 # Two parallel sandboxes in the same directory
-cc --cc-name experiment-a -c
-cc --cc-name experiment-b -c
+cdc --cdc-name experiment-a -c
+cdc --cdc-name experiment-b -c
 
 # One-off: share a folder outside the default mount list
-cc --cc-mount ~/Projects/weird-experiment:ro -c
+cdc --cdc-mount ~/Projects/weird-experiment:ro -c
 
 # One-off: don't let the sandbox see ~/Downloads this session
-cc --cc-no-mount ~/Downloads
+cdc --cdc-no-mount ~/Downloads
 
 # Skip AWS credentials for a session that doesn't need them
-cc --cc-no-mount ~/.aws -c
+cdc --cdc-no-mount ~/.aws -c
 
 # Escape hatch — run host claude directly, bypass sbx entirely
-cc --cc-no-sandbox -c
+cdc --cdc-no-sandbox -c
 ```
 
 ## FAQ
 
-**Does `cc` always run Claude in dangerous-permissions mode?**
+**Does `cdc` always run Claude in dangerous-permissions mode?**
 
 Yes. sbx's claude image has `"defaultMode": "bypassPermissions"` and
 `"bypassPermissionsModeAccepted": true` baked into its
 `/home/agent/.claude/settings.json`. Every Claude invocation inside the
 sandbox bypasses permission prompts. This is not optional when running
-through `cc` — the sandbox is the safety boundary, not the prompts. If you
+through `cdc` — the sandbox is the safety boundary, not the prompts. If you
 need per-command approvals, run plain `claude` on the host (or
-`cc --cc-no-sandbox`), not `cc`.
+`cdc --cdc-no-sandbox`), not `cdc`.
 
 **Can I install a plugin from inside a sandbox session?**
 
@@ -625,14 +625,14 @@ No. Plugins are mounted read-only. Install plugins by running `claude`
 directly on your host, then the plugin will be available in all future
 sandbox sessions automatically (since the directory is shared via symlink).
 
-**Does every `cc` invocation create a new sandbox?**
+**Does every `cdc` invocation create a new sandbox?**
 
 No. The sandbox name is derived deterministically from your current directory
-(`<basename>-<sha1-prefix>`), so `cc` in the same directory always reconnects
+(`<basename>-<sha1-prefix>`), so `cdc` in the same directory always reconnects
 to the same sandbox. Sandboxes persist across reboots until you remove them
-with `cc --cc-rm` or `sbx rm`. First run is slow; subsequent runs are fast.
+with `cdc --cdc-rm` or `sbx rm`. First run is slow; subsequent runs are fast.
 
-**Why is the first `cc` call in a new directory slow?**
+**Why is the first `cdc` call in a new directory slow?**
 
 Three reasons:
 
@@ -640,7 +640,7 @@ Three reasons:
    One-time, shared across all sandboxes.
 2. First run in a new directory: sbx creates a fresh microVM for that
    directory. Usually 15-30 seconds.
-3. Every run: `cc` sleeps 1 second before the final attach as a workaround
+3. Every run: `cdc` sleeps 1 second before the final attach as a workaround
    for an upstream sbx race condition. See the next question.
 
 **What's the 1-second delay about?**
@@ -653,27 +653,27 @@ upstream in sbx. Issue to file: on the roadmap.
 
 **How does authentication work?**
 
-`cc` extracts your host's Claude Code OAuth token from macOS Keychain via
+`cdc` extracts your host's Claude Code OAuth token from macOS Keychain via
 `security find-generic-password -s "Claude Code-credentials"` and pipes it
 into `/home/agent/.claude/.credentials.json` inside the sandbox via
 `sbx exec -i`. This happens on every invocation, so token refreshes on the
 host propagate to the sandbox automatically. The token never lands in a
 shell variable, so `bash -x` cannot leak it.
 
-**Can I share sessions between host `claude` and `cc`?**
+**Can I share sessions between host `claude` and `cdc`?**
 
-Yes. `~/.claude/projects/` is mounted read-write, plus `cc` sets up a
+Yes. `~/.claude/projects/` is mounted read-write, plus `cdc` sets up a
 symlink inside the sandbox from `/home/agent/.claude/projects` to the host
-path. `cc` also uses `sbx exec -w <host-path>` so claude's working directory
+path. `cdc` also uses `sbx exec -w <host-path>` so claude's working directory
 inside the sandbox matches the exact host path — which means session IDs
 (cwd-based) line up between host and sandbox claude. A session started in
-one is resumable from the other with `claude -c` / `cc -c`.
+one is resumable from the other with `claude -c` / `cdc -c`.
 
 **Can I use this on Linux or Windows?**
 
 Linux: probably, with tweaks. The Keychain extraction step is macOS-specific
 (`security` command). On Linux, Claude Code stores credentials in a regular
-file at `~/.claude/.credentials.json`; `cc` would need a code path that
+file at `~/.claude/.credentials.json`; `cdc` would need a code path that
 reads that file instead of calling `security`. PRs welcome.
 
 Windows: untested and unplanned. Would require Docker Desktop for Windows
@@ -681,17 +681,17 @@ and a different credential flow.
 
 **Can I use this with non-Claude agents (Codex, Gemini, etc.)?**
 
-Not currently. sbx supports multiple agents, but `cc`'s credential injection
+Not currently. sbx supports multiple agents, but `cdc`'s credential injection
 is Claude-specific. Making it agent-agnostic would be a meaningful refactor.
 
 ## Roadmap
 
-- [x] `bin/cc` script — parse, plan, preflight, exec phases
+- [x] `bin/cdc` script — parse, plan, preflight, exec phases
 - [x] Auto-authentication from macOS Keychain
 - [x] Session history sharing via symlinks
 - [x] Plugin/skill read-only sharing
 - [x] Color-aware TTY pass-through
-- [x] `--cc-dry-run`, `--cc-doctor`, `--cc-ls`, `--cc-rm`, `--cc-no-sandbox`
+- [x] `--cdc-dry-run`, `--cdc-doctor`, `--cdc-ls`, `--cdc-rm`, `--cdc-no-sandbox`
 - [ ] Manual validation matrix walked through end-to-end
 - [ ] File upstream issue for sbx rapid-call race (currently worked around
       with 1s sleep)

--- a/bin/cdc
+++ b/bin/cdc
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
 #
-# cc — run Claude Code inside a Docker Sandbox microVM
-# https://github.com/patclarke/claude-docker-sandbox
+# cdc — run Claude Code inside a Docker Sandbox microVM
+# https://github.com/patclarke/claude-docker-container
 
 set -euo pipefail
 
-readonly CC_VERSION="0.1.0"
-readonly CC_CONFIG_DIR="$HOME/.config/cc"
-readonly CC_MOUNTS_FILE="$CC_CONFIG_DIR/mounts.conf"
+readonly CDC_VERSION="0.1.0"
+readonly CDC_CONFIG_DIR="$HOME/.config/cdc"
+readonly CDC_MOUNTS_FILE="$CDC_CONFIG_DIR/mounts.conf"
 
 die() {
-	echo "cc: $*" >&2
+	echo "cdc: $*" >&2
 	exit 1
 }
 
@@ -38,22 +38,22 @@ die_preflight() {
 	case "$1" in
 	sbx)
 		cat >&2 <<'EOF'
-cc: sbx not found on PATH.
+cdc: sbx not found on PATH.
     Install:   brew install docker/tap/sbx
     Then run:  sbx login
 EOF
 		;;
 	docker)
-		echo "cc: Docker Desktop is not responding. Run 'docker info' to debug." >&2
+		echo "cdc: Docker Desktop is not responding. Run 'docker info' to debug." >&2
 		;;
 	sbx_auth)
-		echo "cc: sbx is not authenticated. Run: sbx login" >&2
+		echo "cdc: sbx is not authenticated. Run: sbx login" >&2
 		;;
 	claude_dir)
-		echo "cc: $HOME/.claude is missing or not writable. Session history would be lost." >&2
+		echo "cdc: $HOME/.claude is missing or not writable. Session history would be lost." >&2
 		;;
 	claude_binary)
-		echo "cc: claude binary not found on PATH." >&2
+		echo "cdc: claude binary not found on PATH." >&2
 		;;
 	esac
 	exit 1
@@ -63,7 +63,7 @@ ensure_docker_running() {
 	if docker info >/dev/null 2>&1; then
 		return 0
 	fi
-	echo "cc: Docker Desktop is not running. Starting it..." >&2
+	echo "cdc: Docker Desktop is not running. Starting it..." >&2
 	open -a Docker 2>/dev/null || die "failed to launch Docker Desktop."
 	local waited=0
 	while ((waited < 30)); do
@@ -80,7 +80,7 @@ ensure_docker_running() {
 }
 
 run_preflight() {
-	if [[ $CC_NO_SANDBOX -eq 1 ]]; then
+	if [[ $CDC_NO_SANDBOX -eq 1 ]]; then
 		preflight_claude_binary || die_preflight claude_binary
 		return 0
 	fi
@@ -115,22 +115,22 @@ run_rm() {
 	preflight_sbx_auth || die_preflight sbx_auth
 
 	local target
-	if [[ -n "$CC_RM_NAME" ]]; then
-		target="$CC_RM_NAME"
+	if [[ -n "$CDC_RM_NAME" ]]; then
+		target="$CDC_RM_NAME"
 	else
 		target="$(compute_sandbox_name)"
 	fi
 
 	if ! sandbox_exists "$target"; then
-		echo "cc: no sandbox named '$target'" >&2
+		echo "cdc: no sandbox named '$target'" >&2
 		return 1
 	fi
 
-	printf 'cc: remove sandbox "%s"? [y/N] ' "$target" >&2
+	printf 'cdc: remove sandbox "%s"? [y/N] ' "$target" >&2
 	local reply
 	read -r reply
 	if [[ "$reply" != "y" && "$reply" != "Y" ]]; then
-		echo "cc: aborted." >&2
+		echo "cdc: aborted." >&2
 		return 1
 	fi
 	sbx rm "$target"
@@ -138,7 +138,7 @@ run_rm() {
 
 run_doctor() {
 	local fails=0
-	echo "cc doctor"
+	echo "cdc doctor"
 	echo
 
 	if preflight_sbx; then
@@ -172,18 +172,18 @@ run_doctor() {
 	if preflight_claude_binary; then
 		print_check OK "claude installed on host (escape hatch available)"
 	else
-		print_check WARN "claude not on host    (--cc-no-sandbox will fail)"
+		print_check WARN "claude not on host    (--cdc-no-sandbox will fail)"
 	fi
 
 	echo
-	echo "Mount plan (from $CC_MOUNTS_FILE):"
+	echo "Mount plan (from $CDC_MOUNTS_FILE):"
 	load_mounts_config
 	resolve_mounts
-	if [[ ${#CC_RESOLVED_MOUNTS[@]} -eq 0 ]]; then
+	if [[ ${#CDC_RESOLVED_MOUNTS[@]} -eq 0 ]]; then
 		echo "  (empty)"
 	else
 		local entry mode path
-		for entry in "${CC_RESOLVED_MOUNTS[@]}"; do
+		for entry in "${CDC_RESOLVED_MOUNTS[@]}"; do
 			if [[ "$entry" == *:ro ]]; then
 				mode="RO"
 				path="${entry%:ro}"
@@ -196,9 +196,9 @@ run_doctor() {
 	fi
 
 	# shellcheck disable=SC2088
-	if [[ -f "$CC_MOUNTS_FILE" ]] && ! grep -q '~/\.claude/projects' "$CC_MOUNTS_FILE"; then
+	if [[ -f "$CDC_MOUNTS_FILE" ]] && ! grep -q '~/\.claude/projects' "$CDC_MOUNTS_FILE"; then
 		echo
-		echo "WARN: ~/.config/cc/mounts.conf looks out of date (missing ~/.claude/projects)."
+		echo "WARN: ~/.config/cdc/mounts.conf looks out of date (missing ~/.claude/projects)."
 		echo "      Consider deleting it to regenerate with current defaults."
 	fi
 
@@ -213,63 +213,63 @@ run_doctor() {
 
 usage() {
 	cat <<EOF
-cc $CC_VERSION — run Claude Code inside a Docker Sandbox microVM
+cdc $CDC_VERSION — run Claude Code inside a Docker Sandbox microVM
 
 USAGE:
-    cc [CC_FLAGS] [CLAUDE_ARGS...]
+    cdc [CDC_FLAGS] [CLAUDE_ARGS...]
 
-WRAPPER FLAGS (consumed by cc, not forwarded):
-    --cc-name <label>       Named sandbox for parallelism
-    --cc-mount <path>[:ro]  Add an extra mount for this invocation (repeatable)
-    --cc-no-mount <path>    Skip a config-file mount for this invocation (repeatable)
-    --cc-no-sandbox         Escape hatch — exec host claude directly
-    --cc-rm [name]          Remove the sandbox for cwd (or the named one)
-    --cc-ls                 List active sandboxes
-    --cc-dry-run            Print the resolved sbx run command, do not exec
-    --cc-doctor             Run preflight checks + show resolved mount list
-    --cc-help, -h           Show this help
+WRAPPER FLAGS (consumed by cdc, not forwarded):
+    --cdc-name <label>       Named sandbox for parallelism
+    --cdc-mount <path>[:ro]  Add an extra mount for this invocation (repeatable)
+    --cdc-no-mount <path>    Skip a config-file mount for this invocation (repeatable)
+    --cdc-no-sandbox         Escape hatch — exec host claude directly
+    --cdc-rm [name]          Remove the sandbox for cwd (or the named one)
+    --cdc-ls                 List active sandboxes
+    --cdc-dry-run            Print the resolved sbx run command, do not exec
+    --cdc-doctor             Run preflight checks + show resolved mount list
+    --cdc-help, -h           Show this help
 
 Everything else is forwarded to claude inside the sandbox.
 
 EXAMPLES:
-    cc                          # fresh session in cwd
-    cc -c                       # resume most recent session in cwd
-    cc --remote-control -c      # forward arbitrary claude flags
-    cc --cc-name exp-a -c       # named parallel sandbox
-    cc --cc-mount ~/notes:ro    # ad-hoc extra mount
-    cc --cc-no-sandbox -c       # bypass the sandbox entirely
+    cdc                          # fresh session in cwd
+    cdc -c                       # resume most recent session in cwd
+    cdc --remote-control -c      # forward arbitrary claude flags
+    cdc --cdc-name exp-a -c      # named parallel sandbox
+    cdc --cdc-mount ~/notes:ro   # ad-hoc extra mount
+    cdc --cdc-no-sandbox -c      # bypass the sandbox entirely
 
 CONFIG:
-    ~/.config/cc/mounts.conf    Durable mount policy (created on first run)
+    ~/.config/cdc/mounts.conf    Durable mount policy (created on first run)
 EOF
 }
 
 # Parser state — populated by parse_args
-CC_NAME=""
-CC_NO_SANDBOX=0
-CC_DRY_RUN=0
-CC_DOCTOR=0
-CC_LS=0
-CC_RM=0
-CC_RM_NAME=""
-CC_EXTRA_MOUNTS=()
-CC_SKIP_MOUNTS=()
-CC_CONFIG_MOUNTS=()
-CC_RESOLVED_MOUNTS=()
-CC_SBX_ARGV=()
-CC_CREATE_ARGV=()
+CDC_NAME=""
+CDC_NO_SANDBOX=0
+CDC_DRY_RUN=0
+CDC_DOCTOR=0
+CDC_LS=0
+CDC_RM=0
+CDC_RM_NAME=""
+CDC_EXTRA_MOUNTS=()
+CDC_SKIP_MOUNTS=()
+CDC_CONFIG_MOUNTS=()
+CDC_RESOLVED_MOUNTS=()
+CDC_SBX_ARGV=()
+CDC_CREATE_ARGV=()
 CLAUDE_ARGS=()
 
 write_default_mounts_file() {
-	mkdir -p "$CC_CONFIG_DIR"
-	cat >"$CC_MOUNTS_FILE" <<'EOF'
-# cc mounts config
+	mkdir -p "$CDC_CONFIG_DIR"
+	cat >"$CDC_MOUNTS_FILE" <<'EOF'
+# cdc mounts config
 # Format:  <path>[:ro]
 # No suffix = read-write. ":ro" = read-only.
 # Non-existent paths are skipped silently at launch.
 
 # Cross-project reference (read-only view of sibling repos).
-# cc automatically strips any mount that's an ancestor of $PWD, so
+# cdc automatically strips any mount that's an ancestor of $PWD, so
 # this is safe even when cwd is inside ~/workspace.
 ~/workspace:ro
 
@@ -286,19 +286,32 @@ write_default_mounts_file() {
 ~/.claude/plugins:ro
 ~/.claude/skills:ro
 
-# Credentials (RO — read by cc on the host, injected into the sandbox via sbx exec)
+# Credentials (RO — read by cdc on the host, injected into the sandbox via sbx exec)
 ~/.aws:ro
 ~/.config/gh:ro
 ~/.ssh:ro
 EOF
-	echo "cc: created $CC_MOUNTS_FILE with defaults." >&2
+	echo "cdc: created $CDC_MOUNTS_FILE with defaults." >&2
+}
+
+migrate_legacy_config() {
+	# One-time migration: if the new CDC_CONFIG_DIR doesn't exist yet but the
+	# legacy ~/.config/cc/ directory does, rename it. This runs at most once
+	# per user — after the rename, the legacy path is gone and subsequent
+	# calls are a no-op.
+	local legacy_dir="$HOME/.config/cc"
+	if [[ ! -d "$CDC_CONFIG_DIR" && -d "$legacy_dir" ]]; then
+		mv "$legacy_dir" "$CDC_CONFIG_DIR"
+		echo "cdc: migrated config from $legacy_dir to $CDC_CONFIG_DIR (one-time)" >&2
+	fi
 }
 
 load_mounts_config() {
-	if [[ ! -f "$CC_MOUNTS_FILE" ]]; then
+	migrate_legacy_config
+	if [[ ! -f "$CDC_MOUNTS_FILE" ]]; then
 		write_default_mounts_file
 	fi
-	CC_CONFIG_MOUNTS=()
+	CDC_CONFIG_MOUNTS=()
 	local line
 	while IFS= read -r line || [[ -n "$line" ]]; do
 		# strip inline comments and trailing whitespace
@@ -313,8 +326,8 @@ load_mounts_config() {
 		elif [[ "$line" == "~" ]]; then
 			line="$HOME"
 		fi
-		CC_CONFIG_MOUNTS+=("$line")
-	done <"$CC_MOUNTS_FILE"
+		CDC_CONFIG_MOUNTS+=("$line")
+	done <"$CDC_MOUNTS_FILE"
 }
 
 mount_path_only() {
@@ -331,11 +344,11 @@ mount_path_only() {
 }
 
 resolve_mounts() {
-	CC_RESOLVED_MOUNTS=("${CC_CONFIG_MOUNTS[@]+"${CC_CONFIG_MOUNTS[@]}"}")
+	CDC_RESOLVED_MOUNTS=("${CDC_CONFIG_MOUNTS[@]+"${CDC_CONFIG_MOUNTS[@]}"}")
 
-	# Append --cc-mount entries (expand ~)
+	# Append --cdc-mount entries (expand ~)
 	local extra expanded suffix path
-	for extra in "${CC_EXTRA_MOUNTS[@]+"${CC_EXTRA_MOUNTS[@]}"}"; do
+	for extra in "${CDC_EXTRA_MOUNTS[@]+"${CDC_EXTRA_MOUNTS[@]}"}"; do
 		suffix=""
 		path="$extra"
 		if [[ "$extra" == *:ro ]]; then
@@ -350,21 +363,21 @@ resolve_mounts() {
 		else
 			expanded="$path$suffix"
 		fi
-		CC_RESOLVED_MOUNTS+=("$expanded")
+		CDC_RESOLVED_MOUNTS+=("$expanded")
 	done
 
-	# Remove --cc-no-mount entries by absolute-path match
+	# Remove --cdc-no-mount entries by absolute-path match
 	local skip skip_abs new_list current current_abs
-	for skip in "${CC_SKIP_MOUNTS[@]+"${CC_SKIP_MOUNTS[@]}"}"; do
+	for skip in "${CDC_SKIP_MOUNTS[@]+"${CDC_SKIP_MOUNTS[@]}"}"; do
 		skip_abs="$(mount_path_only "$skip")"
 		new_list=()
-		for current in "${CC_RESOLVED_MOUNTS[@]+"${CC_RESOLVED_MOUNTS[@]}"}"; do
+		for current in "${CDC_RESOLVED_MOUNTS[@]+"${CDC_RESOLVED_MOUNTS[@]}"}"; do
 			current_abs="$(mount_path_only "$current")"
 			if [[ "$current_abs" != "$skip_abs" ]]; then
 				new_list+=("$current")
 			fi
 		done
-		CC_RESOLVED_MOUNTS=("${new_list[@]+"${new_list[@]}"}")
+		CDC_RESOLVED_MOUNTS=("${new_list[@]+"${new_list[@]}"}")
 	done
 	filter_existing_mounts
 	strip_cwd_ancestors
@@ -372,33 +385,33 @@ resolve_mounts() {
 
 filter_existing_mounts() {
 	local kept=() entry path
-	for entry in "${CC_RESOLVED_MOUNTS[@]+"${CC_RESOLVED_MOUNTS[@]}"}"; do
+	for entry in "${CDC_RESOLVED_MOUNTS[@]+"${CDC_RESOLVED_MOUNTS[@]}"}"; do
 		path="$(mount_path_only "$entry")"
 		if [[ -e "$path" ]]; then
 			kept+=("$entry")
 		fi
 	done
-	CC_RESOLVED_MOUNTS=("${kept[@]+"${kept[@]}"}")
+	CDC_RESOLVED_MOUNTS=("${kept[@]+"${kept[@]}"}")
 }
 
 strip_cwd_ancestors() {
 	local pwd_abs kept=() entry path
 	pwd_abs="$(pwd -P)"
-	for entry in "${CC_RESOLVED_MOUNTS[@]+"${CC_RESOLVED_MOUNTS[@]}"}"; do
+	for entry in "${CDC_RESOLVED_MOUNTS[@]+"${CDC_RESOLVED_MOUNTS[@]}"}"; do
 		path="$(mount_path_only "$entry")"
 		# Strip if cwd is strictly UNDER this mount (ancestor). Equal is fine — that's the primary.
 		if [[ "$pwd_abs" == "$path"/* && "$pwd_abs" != "$path" ]]; then
-			echo "cc: stripping ancestor mount $path (cwd is inside it)" >&2
+			echo "cdc: stripping ancestor mount $path (cwd is inside it)" >&2
 			continue
 		fi
 		kept+=("$entry")
 	done
-	CC_RESOLVED_MOUNTS=("${kept[@]+"${kept[@]}"}")
+	CDC_RESOLVED_MOUNTS=("${kept[@]+"${kept[@]}"}")
 }
 
 compute_sandbox_name() {
-	if [[ -n "$CC_NAME" ]]; then
-		echo "$CC_NAME"
+	if [[ -n "$CDC_NAME" ]]; then
+		echo "$CDC_NAME"
 		return 0
 	fi
 	local abs basename hash
@@ -424,15 +437,15 @@ inject_credentials() {
 			cat > /home/agent/.claude/.credentials.json &&
 			chmod 600 /home/agent/.claude/.credentials.json
 		' >/dev/null 2>&1; then
-		echo "cc: no Claude Code credentials in macOS Keychain, or injection failed; sandbox claude may prompt /login" >&2
+		echo "cdc: no Claude Code credentials in macOS Keychain, or injection failed; sandbox claude may prompt /login" >&2
 	fi
 	return 0
 }
 
 setup_share_symlinks() {
 	local name="$1" home="$HOME"
-	# Redirect stdin from /dev/null so this sbx exec doesn't steal cc's stdin.
-	# Without the redirect, sbx exec inherits cc's stdin and consumes it, which
+	# Redirect stdin from /dev/null so this sbx exec doesn't steal cdc's stdin.
+	# Without the redirect, sbx exec inherits cdc's stdin and consumes it, which
 	# leaves the final `sbx exec -i ... claude` attach with no stdin and claude
 	# gets SIGKILL'd (exit 137).
 	sbx exec "$name" sh -c "
@@ -484,7 +497,7 @@ build_sbx_argv() {
 	# terminal/color variables into the sandbox. sbx exec does not inherit
 	# the host's TERM/COLORTERM/etc, so without this claude defaults to
 	# minimal/no-color output.
-	CC_SBX_ARGV=(
+	CDC_SBX_ARGV=(
 		sbx exec "$exec_flags" -w "$pwd_abs" "$name"
 		env
 		"TERM=${TERM:-xterm-256color}"
@@ -494,25 +507,25 @@ build_sbx_argv() {
 		claude
 	)
 	if [[ ${#CLAUDE_ARGS[@]} -gt 0 ]]; then
-		CC_SBX_ARGV+=("${CLAUDE_ARGS[@]}")
+		CDC_SBX_ARGV+=("${CLAUDE_ARGS[@]}")
 	fi
 }
 
 build_create_argv() {
-	# Build the sbx create argv for --cc-dry-run display and actual creation.
+	# Build the sbx create argv for --cdc-dry-run display and actual creation.
 	local name pwd_abs
 	name="$(compute_sandbox_name)"
 	pwd_abs="$(pwd -P)"
 
-	CC_CREATE_ARGV=(sbx create claude "$pwd_abs" --name "$name")
+	CDC_CREATE_ARGV=(sbx create claude "$pwd_abs" --name "$name")
 
 	local entry path
-	for entry in "${CC_RESOLVED_MOUNTS[@]+"${CC_RESOLVED_MOUNTS[@]}"}"; do
+	for entry in "${CDC_RESOLVED_MOUNTS[@]+"${CDC_RESOLVED_MOUNTS[@]}"}"; do
 		path="$(mount_path_only "$entry")"
 		if [[ "$path" == "$pwd_abs" ]]; then
 			continue
 		fi
-		CC_CREATE_ARGV+=("$entry")
+		CDC_CREATE_ARGV+=("$entry")
 	done
 }
 
@@ -525,9 +538,9 @@ run_sandbox() {
 	if ! sandbox_exists "$name"; then
 		local create_argv=()
 		build_create_argv
-		create_argv=("${CC_CREATE_ARGV[@]}")
+		create_argv=("${CDC_CREATE_ARGV[@]}")
 		"${create_argv[@]}" || {
-			echo "cc: failed to create sandbox $name" >&2
+			echo "cdc: failed to create sandbox $name" >&2
 			return 1
 		}
 	fi
@@ -545,54 +558,54 @@ run_sandbox() {
 	# practice; under 1s is unreliable.
 	sleep 1
 
-	# Step 4: exec into sbx exec so cc's process becomes sbx exec entirely.
+	# Step 4: exec into sbx exec so cdc's process becomes sbx exec entirely.
 	# Using `exec` avoids any parent-child stdio/signal layering issues
-	# between cc and the attach command.
-	exec "${CC_SBX_ARGV[@]}"
+	# between cdc and the attach command.
+	exec "${CDC_SBX_ARGV[@]}"
 }
 
 parse_args() {
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
-		--cc-help | -h)
+		--cdc-help | -h)
 			usage
 			exit 0
 			;;
-		--cc-name)
-			[[ $# -ge 2 ]] || die "--cc-name requires a value"
-			CC_NAME="$2"
+		--cdc-name)
+			[[ $# -ge 2 ]] || die "--cdc-name requires a value"
+			CDC_NAME="$2"
 			shift 2
 			;;
-		--cc-mount)
-			[[ $# -ge 2 ]] || die "--cc-mount requires a <path>[:ro] value"
-			CC_EXTRA_MOUNTS+=("$2")
+		--cdc-mount)
+			[[ $# -ge 2 ]] || die "--cdc-mount requires a <path>[:ro] value"
+			CDC_EXTRA_MOUNTS+=("$2")
 			shift 2
 			;;
-		--cc-no-mount)
-			[[ $# -ge 2 ]] || die "--cc-no-mount requires a path"
-			CC_SKIP_MOUNTS+=("$2")
+		--cdc-no-mount)
+			[[ $# -ge 2 ]] || die "--cdc-no-mount requires a path"
+			CDC_SKIP_MOUNTS+=("$2")
 			shift 2
 			;;
-		--cc-no-sandbox)
-			CC_NO_SANDBOX=1
+		--cdc-no-sandbox)
+			CDC_NO_SANDBOX=1
 			shift
 			;;
-		--cc-dry-run)
-			CC_DRY_RUN=1
+		--cdc-dry-run)
+			CDC_DRY_RUN=1
 			shift
 			;;
-		--cc-doctor)
-			CC_DOCTOR=1
+		--cdc-doctor)
+			CDC_DOCTOR=1
 			shift
 			;;
-		--cc-ls)
-			CC_LS=1
+		--cdc-ls)
+			CDC_LS=1
 			shift
 			;;
-		--cc-rm)
-			CC_RM=1
+		--cdc-rm)
+			CDC_RM=1
 			if [[ $# -ge 2 && "$2" != -* ]]; then
-				CC_RM_NAME="$2"
+				CDC_RM_NAME="$2"
 				shift 2
 			else
 				shift
@@ -614,17 +627,17 @@ dry_run_output() {
 	local pwd_abs
 	pwd_abs="$(pwd -P)"
 
-	echo "# cc dry-run"
+	echo "# cdc dry-run"
 	echo "CWD=$pwd_abs"
 	echo "SANDBOX_NAME=$(compute_sandbox_name)"
-	echo "NO_SANDBOX=$CC_NO_SANDBOX"
+	echo "NO_SANDBOX=$CDC_NO_SANDBOX"
 	echo
 	echo "MOUNTS (resolved, existing only):"
-	if [[ ${#CC_RESOLVED_MOUNTS[@]} -eq 0 ]]; then
+	if [[ ${#CDC_RESOLVED_MOUNTS[@]} -eq 0 ]]; then
 		echo "  (none)"
 	else
 		local m
-		for m in "${CC_RESOLVED_MOUNTS[@]}"; do
+		for m in "${CDC_RESOLVED_MOUNTS[@]}"; do
 			echo "  $m"
 		done
 	fi
@@ -632,31 +645,31 @@ dry_run_output() {
 	echo "CLAUDE_ARGS: ${CLAUDE_ARGS[*]:-<none>}"
 	echo
 	echo "COMMAND:"
-	printf '  %q ' "${CC_SBX_ARGV[@]}"
+	printf '  %q ' "${CDC_SBX_ARGV[@]}"
 	echo
 }
 
 main() {
 	parse_args "$@"
-	if [[ $CC_DOCTOR -eq 1 ]]; then
+	if [[ $CDC_DOCTOR -eq 1 ]]; then
 		run_doctor
 		return $?
 	fi
-	if [[ $CC_LS -eq 1 ]]; then
+	if [[ $CDC_LS -eq 1 ]]; then
 		run_ls
 		return $?
 	fi
-	if [[ $CC_RM -eq 1 ]]; then
+	if [[ $CDC_RM -eq 1 ]]; then
 		run_rm
 		return $?
 	fi
-	if [[ $CC_DRY_RUN -eq 1 ]]; then
+	if [[ $CDC_DRY_RUN -eq 1 ]]; then
 		dry_run_output
 		return 0
 	fi
 	run_preflight || return 1
 
-	if [[ $CC_NO_SANDBOX -eq 1 ]]; then
+	if [[ $CDC_NO_SANDBOX -eq 1 ]]; then
 		# Escape hatch: bypass sbx entirely, exec host claude directly.
 		exec claude "${CLAUDE_ARGS[@]+"${CLAUDE_ARGS[@]}"}"
 	fi


### PR DESCRIPTION
## Summary

Renames the binary, all flags, the config directory, and every reference
from `cc` to `cdc` (Claude Docker Container). The name `cc` collides
with the system C compiler (`/usr/bin/cc`) on macOS and Linux.

Closes #10

## What changed

### Code (`bin/cc` → `bin/cdc`)

- File renamed via `git mv` so history is preserved (`git log --follow bin/cdc` works)
- All `CC_*` shell variables → `CDC_*`
- All `--cc-*` flags → `--cdc-*` (in parser, usage text, error messages)
- Config dir: `~/.config/cc/` → `~/.config/cdc/`
- Error message prefix: `cc:` → `cdc:`
- Usage header: `cc 0.1.0 — ...` → `cdc 0.1.0 — ...`

### Migration helper

New function `migrate_legacy_config()` in `load_mounts_config`:
- If `~/.config/cdc/` doesn't exist and `~/.config/cc/` does, `mv` it
- Prints a one-line notice: `cdc: migrated config from ~/.config/cc to ~/.config/cdc (one-time)`
- Ran successfully on the author's machine during testing (the legacy dir was migrated automatically)

### Docs (`README.md`, `CLAUDE.md`)

Every reference to `cc`, `--cc-*`, `~/.config/cc/`, and the old repo URL
(`claude-docker-sandbox`) updated to the new names. Install curl URL now
points at `patclarke/claude-docker-container/main/bin/cdc`.

### GitHub repo rename

The repo was renamed from `claude-docker-sandbox` to
`claude-docker-container` prior to this PR (done via `gh repo rename`).
Old URLs redirect. All URL references in README/CLAUDE.md are updated.

## What did NOT change

- Function names (`run_sandbox`, `inject_credentials`, etc.) — they don't have a `cc` prefix
- Sandbox naming logic (still `<basename>-<sha1hash>` derived from cwd)
- LICENSE, version number (`0.1.0`), any behavioral logic
- The local directory name (`~/workspace/claude-docker-sandbox`) — that's the user's local clone, not our concern

## Verification

- [x] `shellcheck bin/cdc` + `shfmt -d bin/cdc` clean
- [x] `./bin/cdc --cdc-help` shows `cdc 0.1.0 — ...`
- [x] `./bin/cdc --cdc-dry-run` shows correct mount list with `~/.config/cdc/mounts.conf`
- [x] `./bin/cdc --cdc-doctor` passes all checks
- [x] `grep -nE '\bcc\b' bin/cdc` — only legitimate matches (legacy path in migration helper)
- [x] `grep -n 'claude-docker-sandbox' README.md CLAUDE.md` — no stale URL references
- [x] `git log --follow bin/cdc` — full history preserved through the rename
- [x] Config migration ran live: `~/.config/cc` → `~/.config/cdc` happened automatically

## For existing users

After merging, existing users need to:
1. Re-download: `curl -fsSL .../bin/cdc -o ~/bin/cdc && chmod +x ~/bin/cdc`
2. Optionally remove old binary: `rm ~/bin/cc`
3. Config is auto-migrated on first `cdc` run — no manual step needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)