### PR TITLE
feat: auto-stop sandbox on exit, add --cdc-keep-running (Closes #9)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,8 +51,10 @@ execution.
 3. **Exec.** If the named sandbox doesn't exist, create it with
    `sbx create claude <primary> <mounts>`. Then inject credentials via
    `sbx exec -i`. Then create sharing symlinks via `sbx exec`. Finally attach
-   with `sbx exec -it <name> env ... claude <claude-args>`, replacing the
-   cdc process via `exec`. Propagate sbx's exit code.
+   with `sbx exec -it <name> env ... claude <claude-args>` in the foreground
+   (not via `exec` — we need to return to cdc after claude exits for cleanup).
+   After claude exits, `cdc` runs `sbx stop` to free the microVM's resources.
+   Pass `--cdc-keep-running` to skip the stop. Propagate sbx's exit code.
 
 The `--cdc-dry-run`, `--cdc-doctor`, and `--cdc-no-sandbox` flags short-circuit
 the exec phase in different ways; they still run parse and the relevant parts

--- a/README.md
+++ b/README.md
@@ -488,6 +488,10 @@ On every invocation, `cdc` does this:
    [your-forwarded-args]`. Claude launches inside the sandbox with your
    terminal's color capability, authenticated, with access to your session
    history.
+7. **Cleanup.** After claude exits (via `/quit`, Ctrl-D, or Ctrl-C), `cdc`
+   runs `sbx stop` on the sandbox to free resources. The sandbox transitions
+   to `stopped` — its state is preserved for next time. Pass
+   `--cdc-keep-running` to skip this step.
 
 The script is ~680 lines of bash at `bin/cdc`. Read it — it's meant to be
 understood.
@@ -577,6 +581,7 @@ through to `claude` untouched.
 | `--cdc-dry-run`            | Print the resolved `sbx` command for this cwd, don't exec      |
 | `--cdc-doctor`             | Run preflight checks and show the resolved mount list          |
 | `--cdc-help`, `-h`         | Usage                                                          |
+| `--cdc-keep-running`       | Don't stop the sandbox after claude exits                      |
 
 ### Common invocations
 
@@ -650,6 +655,24 @@ set up symlinks, attach) leaves sbx's daemon in a state where the next
 interactive exec is SIGKILL'd at startup (exit 137). A 1-second pause before
 the final attach lets the daemon settle. It's a workaround; the real fix is
 upstream in sbx. Issue to file: on the roadmap.
+
+**Does the sandbox stay running after I exit?**
+
+No. By default, `cdc` runs `sbx stop` on the sandbox after claude exits.
+This frees the microVM's memory and CPU. The sandbox transitions to `stopped`
+state — its filesystem and mount config are preserved, and the next `cdc`
+invocation from the same directory restarts it in a few seconds.
+
+If you want the sandbox to stay running (for faster reconnect or because
+you're running multiple terminals against the same sandbox), pass
+`--cdc-keep-running`:
+
+```bash
+cdc --cdc-keep-running -c
+```
+
+You can also stop all running sandboxes manually at any time with
+`sbx stop $(sbx ls -q)`.
 
 **How does authentication work?**
 

--- a/bin/cdc
+++ b/bin/cdc
@@ -228,6 +228,7 @@ WRAPPER FLAGS (consumed by cdc, not forwarded):
     --cdc-dry-run            Print the resolved sbx run command, do not exec
     --cdc-doctor             Run preflight checks + show resolved mount list
     --cdc-help, -h           Show this help
+    --cdc-keep-running      Don't stop the sandbox after claude exits
 
 Everything else is forwarded to claude inside the sandbox.
 
@@ -627,6 +628,10 @@ parse_args() {
 				shift
 			fi
 			;;
+		--cdc-keep-running)
+			CDC_KEEP_RUNNING=1
+			shift
+			;;
 		*)
 			CLAUDE_ARGS+=("$1")
 			shift
@@ -647,6 +652,7 @@ dry_run_output() {
 	echo "CWD=$pwd_abs"
 	echo "SANDBOX_NAME=$(compute_sandbox_name)"
 	echo "NO_SANDBOX=$CDC_NO_SANDBOX"
+	echo "KEEP_RUNNING=$CDC_KEEP_RUNNING"
 	echo
 	echo "MOUNTS (resolved, existing only):"
 	if [[ ${#CDC_RESOLVED_MOUNTS[@]} -eq 0 ]]; then

--- a/bin/cdc
+++ b/bin/cdc
@@ -252,6 +252,7 @@ CDC_DOCTOR=0
 CDC_LS=0
 CDC_RM=0
 CDC_RM_NAME=""
+CDC_KEEP_RUNNING=0
 CDC_EXTRA_MOUNTS=()
 CDC_SKIP_MOUNTS=()
 CDC_CONFIG_MOUNTS=()
@@ -551,17 +552,32 @@ run_sandbox() {
 	# Step 3: set up sharing symlinks (idempotent)
 	setup_share_symlinks "$name"
 
-	# sbx race workaround: rapid successive sbx calls (create, exec for inject,
-	# exec for symlinks, then exec for attach) leave the sbx daemon in a state
-	# where the interactive attach is SIGKILL'd at startup (exit 137). A brief
-	# pause before the attach lets the daemon settle. 1s is sufficient in
-	# practice; under 1s is unreliable.
+	# sbx race workaround: rapid successive sbx calls leave the sbx daemon in
+	# a state where the next interactive exec is SIGKILL'd at startup (exit 137).
+	# A brief pause before the attach lets the daemon settle.
 	sleep 1
 
-	# Step 4: exec into sbx exec so cdc's process becomes sbx exec entirely.
-	# Using `exec` avoids any parent-child stdio/signal layering issues
-	# between cdc and the attach command.
-	exec "${CDC_SBX_ARGV[@]}"
+	# Step 4: run claude in the foreground. We use a foreground call (not exec)
+	# so we can run cleanup (sbx stop) after claude exits. The sleep above
+	# handles the 137 race that originally motivated the exec.
+	local rc=0
+
+	# Register cleanup trap so sandbox stops even on Ctrl-C / SIGTERM
+	if [[ $CDC_KEEP_RUNNING -eq 0 ]]; then
+		trap 'sbx stop "$name" >/dev/null 2>&1 || true; exit 130' INT TERM
+	fi
+
+	"${CDC_SBX_ARGV[@]}" || rc=$?
+
+	# Clean up trap
+	trap - INT TERM
+
+	# Auto-stop the sandbox to free resources (unless --cdc-keep-running)
+	if [[ $CDC_KEEP_RUNNING -eq 0 ]]; then
+		sbx stop "$name" >/dev/null 2>&1 || true
+	fi
+
+	return "$rc"
 }
 
 parse_args() {


### PR DESCRIPTION
## Summary

After a user exits Claude Code inside the sandbox, `cdc` now automatically
runs `sbx stop` on the sandbox to free the microVM's memory and CPU. The
sandbox transitions to `stopped` — its filesystem and mount config are
preserved, and the next `cdc` invocation from the same directory restarts
it in a few seconds.

Pass `--cdc-keep-running` to opt out and keep the sandbox running (for
faster reconnect or multi-terminal use).

Closes #9

## Changes

### Core behavior (`bin/cdc`)

- **Replaced `exec` with foreground call + cleanup.** The `exec` that
  previously replaced cdc's process with `sbx exec` is gone. Instead,
  `sbx exec` runs in the foreground, and after it returns (user quit
  claude), `cdc` runs `sbx stop` to free the microVM.

- **Trap for Ctrl-C / SIGTERM.** If the user interrupts with Ctrl-C
  during a session, a trap handler runs `sbx stop` before exiting. This
  ensures cleanup happens on both clean and interrupted exits.

- **`--cdc-keep-running` flag.** When set, skips both the trap and the
  `sbx stop` after exit. Sandbox stays running. Visible in
  `--cdc-dry-run` output (`KEEP_RUNNING=1`).

- **The `sleep 1` race workaround is preserved.** The exec was NOT what
  fixed the 137 SIGKILL issue — the sleep was. Removing exec doesn't
  re-introduce the race.

### Docs

- README: new flag in the reference table, new FAQ entry ("Does the
  sandbox stay running after I exit?"), new step 7 in "How it works"
- CLAUDE.md: updated exec-phase description to reflect foreground-call
  + cleanup pattern

## Verification

- [x] `shellcheck bin/cdc` + `shfmt -d bin/cdc` clean
- [x] `--cdc-help` shows `--cdc-keep-running`
- [x] `--cdc-dry-run` shows `KEEP_RUNNING=0` (default)
- [x] `--cdc-dry-run --cdc-keep-running` shows `KEEP_RUNNING=1`
- [x] `--cdc-doctor` still works
- [x] No `exec "${CDC_SBX_ARGV[@]}"` remaining in the script
- [x] `sbx stop` appears in trap handler + normal cleanup path

## Still needs live testing

- [ ] `cdc -p "say OK"` → exits cleanly, then `sbx ls` shows sandbox
      as `stopped` (not `running`)
- [ ] `cdc --cdc-keep-running -p "say OK"` → sandbox stays `running`
- [ ] Interactive `cdc` → Ctrl-C mid-session → sandbox stops
- [ ] No 137 recurrence with the exec removed (sleep 1 is the real fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)