### PR TITLE
feat: --cdc-doctor auto-starts Docker Desktop (Closes #7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,12 @@ Mount plan (from /Users/you/.config/cdc/mounts.conf):
 All checks passed.
 ```
 
+If Docker Desktop isn't running when you run `cdc --cdc-doctor`, it will
+attempt to start it automatically (same as a normal `cdc` invocation) and
+wait up to 30 seconds. If Docker comes up, the check reports OK. If not,
+it reports FAIL and continues with the remaining checks so you still see
+the full picture.
+
 If anything is `FAIL`, the doctor prints exactly which step you need to
 revisit. The first time you run `cdc --cdc-doctor`, it creates
 `~/.config/cdc/mounts.conf` with the default mount policy.

--- a/bin/cdc
+++ b/bin/cdc
@@ -148,10 +148,29 @@ run_doctor() {
 		fails=$((fails + 1))
 	fi
 
+	# Auto-start Docker if it's not running, same as the normal cdc exec path.
+	# Unlike ensure_docker_running (which calls die on failure), this inline
+	# version continues to the remaining checks so doctor always reports the
+	# full picture.
+	if ! docker info >/dev/null 2>&1; then
+		echo "  Docker Desktop is not running. Attempting to start it..." >&2
+		open -a Docker 2>/dev/null || true
+		local docker_waited=0
+		while ((docker_waited < 30)); do
+			if docker info >/dev/null 2>&1; then
+				break
+			fi
+			sleep 1
+			docker_waited=$((docker_waited + 1))
+			printf '.' >&2
+		done
+		[[ $docker_waited -gt 0 ]] && echo >&2
+	fi
+
 	if preflight_docker; then
 		print_check OK "Docker Desktop running"
 	else
-		print_check FAIL "Docker Desktop running    (open -a Docker)"
+		print_check FAIL "Docker Desktop running    (could not start within 30s)"
 		fails=$((fails + 1))
 	fi
 


### PR DESCRIPTION
## Summary

`cdc --cdc-doctor` now attempts to start Docker Desktop if it's not running,
same as the normal `cdc` execution path. Waits up to 30 seconds. If Docker
comes up, reports OK. If not, reports FAIL and continues with remaining checks.

Closes #7

## What changed

- `bin/cdc`: ~12 lines of inline auto-start logic in `run_doctor()`, right
  before the `preflight_docker` check. Intentionally does NOT call
  `ensure_docker_running` (which `die`s on failure) — doctor should always
  complete all checks and report the full picture.
- `README.md`: updated the Step 6 health check description to document the
  new auto-start behavior.

## Why inline instead of reusing `ensure_docker_running`

`ensure_docker_running` calls `die` if Docker fails to start within 30s.
That's correct for the normal exec path (you can't proceed without Docker),
but wrong for doctor mode: a user running `--cdc-doctor` wants to see ALL
check statuses, not just the first failure. The inline version tries
auto-start, reports the result, and moves on to the next check regardless.

## Test plan

- [x] `shellcheck bin/cdc` + `shfmt -d bin/cdc` clean
- [x] `cdc --cdc-doctor` with Docker running → all OK (auto-start not triggered)
- [ ] `cdc --cdc-doctor` with Docker NOT running → "Attempting to start..."
      message, dots, then OK if it comes up within 30s
- [ ] `cdc --cdc-doctor` with Docker broken → FAIL reported, remaining
      checks still run

🤖 Generated with [Claude Code](https://claude.com/claude-code)