### PR TITLE
docs: improve project dir config discoverability (Closes #8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,13 @@ If anything is `FAIL`, the doctor prints exactly which step you need to
 revisit. The first time you run `cdc --cdc-doctor`, it creates
 `~/.config/cdc/mounts.conf` with the default mount policy.
 
+**One thing to check:** the default config assumes your projects live in
+`~/workspace`. If you keep code somewhere else (like `~/code`, `~/dev`,
+or `~/Projects`), open `~/.config/cdc/mounts.conf` and change the
+`~/workspace:ro` line to your actual projects directory. This gives the
+sandbox read-only access to sibling repos for cross-project context. If
+the path doesn't exist, it's silently ignored — no harm done.
+
 **You're done.** Jump to [Quick start](#quick-start) to actually run
 something.
 

--- a/bin/cdc
+++ b/bin/cdc
@@ -290,8 +290,11 @@ write_default_mounts_file() {
 # Non-existent paths are skipped silently at launch.
 
 # Cross-project reference (read-only view of sibling repos).
-# cdc automatically strips any mount that's an ancestor of $PWD, so
-# this is safe even when cwd is inside ~/workspace.
+# CHANGE THIS to wherever you keep your code projects — e.g.:
+#   ~/code:ro    ~/dev:ro    ~/Projects:ro    ~/src:ro
+# If the path doesn't exist on your machine, it's silently ignored.
+# cdc automatically strips this mount when cwd is inside it, so it's
+# safe even when you're working inside the directory listed here.
 ~/workspace:ro
 
 # Ad-hoc file sharing from normal macOS locations


### PR DESCRIPTION
## Summary

Instead of adding heuristic auto-detection for project directories (which
is unreliable and runs once), improves documentation so users know to
customize the `~/workspace:ro` line in their config.

Closes #8

## Changes

1. **`bin/cdc` default config comment** — expanded from 2 lines to 5 lines.
   Now lists common alternatives inline (`~/code:ro`, `~/dev:ro`,
   `~/Projects:ro`, `~/src:ro`) and explains that missing paths are
   silently ignored.

2. **README Install section** — added a "one thing to check" note right
   after the first-run health check, pointing users at the config file
   and explaining what to change if their projects aren't in `~/workspace`.

## Why not auto-detection

See the discussion in #8. Short version: heuristic detection is unreliable
(users have multiple project dirs, detection picks wrong one), only runs
once (user still edits manually on mismatch), and "wrong default I didn't
ask for" is worse than "no default." The real fix is the install script
(#11) which can ask interactively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)