### PR TITLE
feat: add install.sh one-liner installer (Closes #11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,8 +345,21 @@ you don't have any sandboxes yet).
 
 ### Step 5: install `cdc`
 
-`cdc` itself is a single bash script. Drop it into `~/bin` and put that
-directory on your PATH:
+`cdc` itself is a single bash script. The easiest way to install it is
+with the one-liner installer, which downloads `cdc` to `~/bin`, detects
+your shell (zsh or bash), and adds `~/bin` to your PATH automatically:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/patclarke/claude-docker-container/main/install.sh | bash
+```
+
+The installer also runs `cdc --cdc-doctor` at the end as a health check.
+
+**After the install finishes, open a new terminal** so the PATH change
+takes effect, then skip to Step 6.
+
+<details>
+<summary>Prefer to install manually?</summary>
 
 ```bash
 # Create ~/bin and download cdc into it
@@ -373,10 +386,12 @@ which cdc
 
 Should print: `/Users/<your-username>/bin/cdc`
 
+</details>
+
 ### Step 6: final health check
 
-`cdc` has a built-in health check that runs through everything from Steps
-2–4 and reports the status:
+If you used the one-liner installer above, the doctor already ran. In a
+**new terminal** (so PATH is updated), verify everything:
 
 ```bash
 cdc --cdc-doctor

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+#
+# cdc installer — downloads bin/cdc and sets up PATH.
+#
+# Prerequisites (not handled by this script):
+#   - Docker Desktop:  brew install --cask docker
+#   - Claude Code:     https://claude.com/claude-code
+#   - sbx:             brew install docker/tap/sbx && sbx login
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/patclarke/claude-docker-container/main/install.sh | bash
+#
+# https://github.com/patclarke/claude-docker-container
+
+set -euo pipefail
+
+CDC_URL="https://raw.githubusercontent.com/patclarke/claude-docker-container/main/bin/cdc"
+INSTALL_DIR="$HOME/bin"
+INSTALL_PATH="$INSTALL_DIR/cdc"
+
+echo "cdc installer"
+echo ""
+
+# --- Step 1: download cdc ---------------------------------------------------
+
+mkdir -p "$INSTALL_DIR"
+
+echo "Downloading cdc to $INSTALL_PATH..."
+if ! curl -fsSL "$CDC_URL" -o "$INSTALL_PATH"; then
+	echo "ERROR: failed to download cdc. Check your network connection." >&2
+	exit 1
+fi
+chmod +x "$INSTALL_PATH"
+echo "  ✓ Downloaded cdc to $INSTALL_PATH"
+
+# --- Step 2: add ~/bin to PATH ----------------------------------------------
+
+SHELL_NAME="$(basename "${SHELL:-/bin/zsh}")"
+
+case "$SHELL_NAME" in
+zsh)
+	RC_FILE="$HOME/.zshrc"
+	;;
+bash)
+	if [[ "$(uname)" == "Darwin" ]]; then
+		RC_FILE="$HOME/.bash_profile"
+	else
+		RC_FILE="$HOME/.bashrc"
+	fi
+	;;
+*)
+	echo ""
+	echo "  ⚠️  Unknown shell: $SHELL_NAME"
+	echo "  Add this to your shell config manually:"
+	echo ""
+	echo "    export PATH=\"\$HOME/bin:\$PATH\""
+	echo ""
+	echo "  Then open a new terminal and run: cdc --cdc-doctor"
+	exit 0
+	;;
+esac
+
+# Single quotes intentional: we want the literal string written to the
+# rc file, not expanded at install time.
+# shellcheck disable=SC2016
+PATH_LINE='export PATH="$HOME/bin:$PATH"'
+
+if grep -qF "$PATH_LINE" "$RC_FILE" 2>/dev/null; then
+	echo "  ✓ ~/bin already on PATH in $RC_FILE"
+else
+	# Create the rc file if it doesn't exist (fresh macOS installs may not have .zshrc)
+	touch "$RC_FILE"
+	{
+		echo ""
+		echo "# Added by cdc installer (https://github.com/patclarke/claude-docker-container)"
+		echo "$PATH_LINE"
+	} >>"$RC_FILE"
+	echo "  ✓ Added ~/bin to PATH in $RC_FILE"
+fi
+
+# --- Step 3: verify ---------------------------------------------------------
+
+echo ""
+
+# Add ~/bin to PATH for this session so we can run cdc right now
+export PATH="$INSTALL_DIR:$PATH"
+
+if command -v cdc >/dev/null 2>&1; then
+	echo "Running cdc --cdc-doctor..."
+	echo ""
+	cdc --cdc-doctor || true
+else
+	echo "  ⚠️  cdc not found on PATH after install. This shouldn't happen."
+	echo "  Try opening a new terminal and running: cdc --cdc-doctor"
+fi
+
+# --- Done --------------------------------------------------------------------
+
+echo ""
+echo "Install complete."
+echo ""
+echo "  → Open a new terminal so PATH takes effect, then run:"
+echo "    cdc --cdc-doctor"
+echo ""
+echo "Prerequisites not handled by this script:"
+echo "  - Docker Desktop:  brew install --cask docker"
+echo "  - Claude Code:     https://claude.com/claude-code"
+echo "  - sbx:             brew install docker/tap/sbx && sbx login"
+echo ""
+echo "Full setup guide: https://github.com/patclarke/claude-docker-container#install"


### PR DESCRIPTION
## Summary

Adds a one-liner installer so Step 5 of the README becomes:

```bash
curl -fsSL https://raw.githubusercontent.com/patclarke/claude-docker-container/main/install.sh | bash
```

Instead of 6 manual commands with shell-specific rc file editing.

Closes #11

## What the script does

1. Downloads `bin/cdc` from GitHub to `~/bin/cdc`, `chmod +x`
2. Detects user's shell via `$SHELL` (zsh or bash)
3. Picks the right rc file (`~/.zshrc`, `~/.bash_profile`, or `~/.bashrc`)
4. Idempotently adds `export PATH="$HOME/bin:$PATH"` (skips if already present)
5. Runs `cdc --cdc-doctor` as a final health check
6. Prints next steps (open new terminal, prerequisite reminders)

## What the script does NOT do

- Install Docker Desktop (GUI, needs terms agreement)
- Install Claude Code (interactive `/login`)
- Install sbx (needs `sbx login` browser flow)
- Handle fish shell (prints manual instructions for unknown shells)

These stay as manual README steps 1–4.

## README changes

Step 5 now leads with the one-liner. The previous manual instructions
are collapsed into a `<details>` block for users who prefer to see
each command explicitly.

## Test plan

- [x] `shellcheck install.sh` + `shfmt -d install.sh` clean
- [x] Script is idempotent (safe to re-run: re-downloads cdc,
      skips PATH if already added)
- [ ] Test on a fresh macOS zsh environment
- [ ] Test on bash (change `$SHELL` or use `bash -l`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)