### PR TITLE
fix: install.sh prints source command for immediate PATH activation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -97,10 +97,12 @@ fi
 # --- Done --------------------------------------------------------------------
 
 echo ""
-echo "Install complete."
+echo "Install complete!"
 echo ""
-echo "  → Open a new terminal so PATH takes effect, then run:"
-echo "    cdc --cdc-doctor"
+echo "  → To use cdc in this terminal right now, run:"
+echo "    source $RC_FILE"
+echo ""
+echo "  Or just open a new terminal — PATH will be set automatically."
 echo ""
 echo "Prerequisites not handled by this script:"
 echo "  - Docker Desktop:  brew install --cask docker"


### PR DESCRIPTION
## Summary

The install script told users to "open a new terminal" after install,
but didn't mention they could just `source ~/.zshrc` to activate PATH
immediately. Users who ran the installer and then typed `cdc` in the
same terminal got `command not found`.

Now the installer prints:

```
Install complete!

  → To use cdc in this terminal right now, run:
    source /Users/you/.zshrc

  Or just open a new terminal — PATH will be set automatically.
```

This was supposed to land in PR #17 but was pushed after the merge.

## Test plan

- [x] `shellcheck install.sh` clean
- [x] Output includes `source $RC_FILE` with the actual detected path

🤖 Generated with [Claude Code](https://claude.com/claude-code)