### PR TITLE
fix: explicitly pass --dangerously-skip-permissions, add --cdc-safe-mode (Closes #23)

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,6 +548,7 @@ through to `claude` untouched.
 | `--cdc-doctor`             | Run preflight checks and show the resolved mount list          |
 | `--cdc-help`, `-h`         | Usage                                                          |
 | `--cdc-keep-running`       | Don't stop the sandbox after claude exits                      |
+| `--cdc-safe-mode`          | Run claude with permission prompts (no `--dangerously-skip-permissions`) |
 
 ### Common invocations
 

--- a/bin/cdc
+++ b/bin/cdc
@@ -248,6 +248,7 @@ WRAPPER FLAGS (consumed by cdc, not forwarded):
     --cdc-doctor             Run preflight checks + show resolved mount list
     --cdc-help, -h           Show this help
     --cdc-keep-running      Don't stop the sandbox after claude exits
+    --cdc-safe-mode         Don't pass --dangerously-skip-permissions to claude
 
 Everything else is forwarded to claude inside the sandbox.
 
@@ -273,6 +274,7 @@ CDC_LS=0
 CDC_RM=0
 CDC_RM_NAME=""
 CDC_KEEP_RUNNING=0
+CDC_SAFE_MODE=0
 CDC_EXTRA_MOUNTS=()
 CDC_SKIP_MOUNTS=()
 CDC_CONFIG_MOUNTS=()
@@ -530,6 +532,16 @@ build_sbx_argv() {
 		"LC_ALL=${LC_ALL:-en_US.UTF-8}"
 		claude
 	)
+
+	# Always pass --dangerously-skip-permissions unless --cdc-safe-mode is set.
+	# We cannot rely on sbx's baked-in settings.json having defaultMode:
+	# bypassPermissions — Claude Code ignores that setting in environments it
+	# considers "Remote" (IS_SANDBOX=1 triggers this). The CLI flag is the only
+	# reliable way to enable bypass mode. The sandbox IS the safety boundary.
+	if [[ $CDC_SAFE_MODE -eq 0 ]]; then
+		CDC_SBX_ARGV+=(--dangerously-skip-permissions)
+	fi
+
 	if [[ ${#CLAUDE_ARGS[@]} -gt 0 ]]; then
 		CDC_SBX_ARGV+=("${CLAUDE_ARGS[@]}")
 	fi
@@ -654,6 +666,10 @@ parse_args() {
 			CDC_KEEP_RUNNING=1
 			shift
 			;;
+		--cdc-safe-mode)
+			CDC_SAFE_MODE=1
+			shift
+			;;
 		*)
 			CLAUDE_ARGS+=("$1")
 			shift
@@ -675,6 +691,7 @@ dry_run_output() {
 	echo "SANDBOX_NAME=$(compute_sandbox_name)"
 	echo "NO_SANDBOX=$CDC_NO_SANDBOX"
 	echo "KEEP_RUNNING=$CDC_KEEP_RUNNING"
+	echo "SAFE_MODE=$CDC_SAFE_MODE"
 	echo
 	echo "MOUNTS (resolved, existing only):"
 	if [[ ${#CDC_RESOLVED_MOUNTS[@]} -eq 0 ]]; then


### PR DESCRIPTION
## Summary

Claude inside the sandbox was not running in dangerous-permissions mode
despite sbx's settings.json containing `"defaultMode": "bypassPermissions"`.
Root cause: Claude Code ignores that setting in environments where
`IS_SANDBOX=1` (which sbx sets), treating them as "Remote environments"
where only `acceptEdits` or `plan` modes are honored from settings.

Fix: always pass `--dangerously-skip-permissions` as a CLI flag to claude.
The CLI flag takes precedence over everything — settings.json, feature flags,
environment detection.

Also adds `--cdc-safe-mode` for users who want permission prompts inside
the sandbox.

Closes #23

## Changes

### `bin/cdc`

- `build_sbx_argv` now appends `--dangerously-skip-permissions` to the
  claude command unless `CDC_SAFE_MODE=1`
- New parser state var `CDC_SAFE_MODE=0` (default: dangerous mode ON)
- New flag `--cdc-safe-mode` in parser + usage text + dry-run output
- Comment explains WHY the CLI flag is needed (settings.json unreliable)

### `README.md`

- New row in the flags table for `--cdc-safe-mode`

## Verification

```
$ cdc --cdc-dry-run 2>&1 | grep -E "SAFE|dangerous"
SAFE_MODE=0
  ... claude --dangerously-skip-permissions

$ cdc --cdc-safe-mode --cdc-dry-run 2>&1 | grep -E "SAFE|dangerous"
SAFE_MODE=1
  ... claude    (no --dangerously-skip-permissions)
```

## Test plan

- [x] `shellcheck bin/cdc` + `shfmt -d bin/cdc` clean
- [x] Default dry-run shows `--dangerously-skip-permissions` in COMMAND
- [x] `--cdc-safe-mode` dry-run omits the flag
- [x] Help text shows both `--cdc-keep-running` and `--cdc-safe-mode`
- [ ] Live test: `cdc` → claude should NOT prompt for permissions
- [ ] Live test: `cdc --cdc-safe-mode` → claude SHOULD prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)