### PR TITLE
feat(doctor): warn when sbx github secret is missing

### DIFF
--- a/bin/cdc
+++ b/bin/cdc
@@ -36,11 +36,14 @@ preflight_claude_binary() {
 
 preflight_github_secret() {
 	# sbx proxies git-over-HTTPS and api.github.com requests through a host-side
-	# token store. Without a `github` secret registered (global or per-sandbox),
-	# `git push` inside the sandbox fails with "could not read Username".
-	# Match the first whitespace-delimited column against "github" so header
-	# rows (e.g. "NAME SCOPE") and secret values are ignored.
-	sbx secret list -g 2>/dev/null | awk '$1 == "github" {f=1} END {exit !f}'
+	# token store. Without a `github` secret registered, `git push` inside the
+	# sandbox fails with "could not read Username".
+	#
+	# `sbx secret list -g` output format:
+	#   SCOPE      SERVICE   SECRET
+	#   (global)   github    gho_****
+	# The SERVICE column (field 2) is what we match against.
+	sbx secret list -g 2>/dev/null | awk '$2 == "github" {f=1} END {exit !f}'
 }
 
 die_preflight() {

--- a/bin/cdc
+++ b/bin/cdc
@@ -34,6 +34,15 @@ preflight_claude_binary() {
 	command -v claude >/dev/null 2>&1
 }
 
+preflight_github_secret() {
+	# sbx proxies git-over-HTTPS and api.github.com requests through a host-side
+	# token store. Without a `github` secret registered (global or per-sandbox),
+	# `git push` inside the sandbox fails with "could not read Username".
+	# Match the first whitespace-delimited column against "github" so header
+	# rows (e.g. "NAME SCOPE") and secret values are ignored.
+	sbx secret list -g 2>/dev/null | awk '$1 == "github" {f=1} END {exit !f}'
+}
+
 die_preflight() {
 	case "$1" in
 	sbx)
@@ -192,6 +201,12 @@ run_doctor() {
 		print_check OK "claude installed on host (escape hatch available)"
 	else
 		print_check WARN "claude not on host    (--cdc-no-sandbox will fail)"
+	fi
+
+	if preflight_github_secret; then
+		print_check OK "sbx github secret set (git over HTTPS will work inside sandbox)"
+	else
+		print_check WARN "no sbx github secret    (fix: sbx secret set -g github -t \"\$(gh auth token)\")"
 	fi
 
 	echo


### PR DESCRIPTION
## Summary

Adds a WARN-level check to `cdc --cdc-doctor` that fires when sbx's `github` secret is not set. Without that secret, `git push` over HTTPS inside the sandbox fails with a cryptic `could not read Username` error, and new users have no clear way to discover the fix.

The new line looks like:

```
WARN  no sbx github secret    (fix: sbx secret set -g github -t "$(gh auth token)")
```

Implements piece 1 of #30. Pieces 2 (README section) and 3 (auto-set the secret in `install.sh`) will follow in a separate PR.

## Design notes

- **WARN, not FAIL.** `cdc` works fine without GitHub auth for pure-coding sessions; we don't want to block users who don't need it.
- **Parsing approach.** Uses `awk '$1 == "github"'` on `sbx secret list -g`, which is robust to header rows (e.g. `NAME SCOPE`) and to secret values appearing on the same line. If `sbx` later gains a `--format json` flag, worth revisiting.
- **Global only.** The check reads `sbx secret list -g` (global). Per-sandbox secrets would also satisfy the need, but the fix remedy in the WARN line points to the global setup, and covering both in the check wasn't worth the complexity for a single-user tool.

## Test plan

- [ ] `sbx secret list -g` on host confirms the output format the awk expects (verify `github` appears as `$1`).
- [ ] With no `github` secret: `cdc --cdc-doctor` prints the WARN line, exit code stays 0.
- [ ] After `sbx secret set -g github -t "$(gh auth token)"`: `cdc --cdc-doctor` prints the OK line.
- [ ] `shellcheck bin/cdc` + `shfmt -d bin/cdc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)