### PR TITLE
feat: onboard GitHub access from the sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Run Claude Code in dangerous mode safely inside a fast, easy-to-use microVM that
 - [Quick Use](#quick-use)
 - [Install](#install)
 - [Updating](#updating)
+- [GitHub access from the sandbox](#github-access-from-the-sandbox)
 - [Quick start](#quick-start)
 - [How it works](#how-it-works)
 - [Configuration](#configuration)
@@ -491,6 +492,68 @@ ln -sf ~/src/claude-docker-container/bin/cdc ~/bin/cdc
 
 Then `cd ~/src/claude-docker-container && git pull` whenever you want the
 latest.
+
+## GitHub access from the sandbox
+
+The sandbox doesn't inherit your host's `gh` CLI login. Instead, `sbx` ships a
+host-side proxy that transparently injects a GitHub token into outbound HTTPS
+traffic from inside the sandbox. For that to work, the token has to live in
+sbx's secret store — `cdc` doesn't manage it for you.
+
+**The installer sets this up automatically.** If `gh` is installed and logged
+in when you run the installer, it runs the equivalent of:
+
+```bash
+sbx secret set -g github -t "$(gh auth token)"
+```
+
+If that didn't happen (e.g. you installed `gh` after `cdc`, or you were
+logged out at install time), `cdc --cdc-doctor` will print a `WARN` line with
+the exact command to run.
+
+### What works, what doesn't
+
+| What you run inside the sandbox | Works? | Why |
+|---|---|---|
+| `git clone/fetch/push` over HTTPS | Yes | Proxy injects the token at the network layer |
+| `curl https://api.github.com/...` | Yes | Same |
+| `git` over SSH (`git@github.com:...`) | Yes | `~/.ssh` is mounted read-only |
+| `gh` CLI (`gh pr create`, `gh issue view`, ...) | **No** | Reads its own token from the host Keychain, which the sandbox can't see |
+
+The `gh` CLI gap is rarely a blocker in practice — anything `gh` does, you
+can do with a `curl` against `api.github.com`. Example, creating a PR:
+
+```bash
+curl -sS -X POST https://api.github.com/repos/OWNER/REPO/pulls \
+  -H "Accept: application/vnd.github+json" \
+  -d '{"title":"…","head":"my-branch","base":"main","body":"…"}'
+```
+
+No token header needed — the proxy adds it.
+
+### Gotcha: global secrets and existing sandboxes
+
+`sbx secret set -g github` only takes effect for sandboxes created **after**
+the secret was set. If you set the secret and an existing sandbox still
+can't authenticate, recreate it:
+
+```bash
+cdc --cdc-rm
+cdc
+```
+
+### Security note
+
+The token is stored in sbx's host-side proxy store. Agents running inside
+the sandbox cannot read the token directly — they can only *use* it by
+making GitHub API calls that the proxy intercepts. This is why `cdc` uses
+sbx secrets for GitHub instead of injecting a credential file into the
+sandbox filesystem the way it does for the Claude Code OAuth token.
+
+A prompt-injected agent can still *use* your GitHub permissions while it's
+running (delete repos, push malicious code, etc.). Scope your token or
+switch to fine-grained GitHub tokens if that's a concern. See
+[Recommended: credential scoping](#recommended-credential-scoping).
 
 ## Quick start
 

--- a/install.sh
+++ b/install.sh
@@ -94,6 +94,31 @@ else
 	echo "  Try opening a new terminal and running: cdc --cdc-doctor"
 fi
 
+# --- Step 4: set sbx github secret from gh auth token -----------------------
+#
+# Without this, git over HTTPS and api.github.com requests from inside the
+# sandbox fail silently. The token is stored in sbx's host-side proxy store,
+# not injected into the sandbox filesystem, so agents inside the sandbox
+# never see it directly.
+
+if command -v sbx >/dev/null 2>&1 && command -v gh >/dev/null 2>&1; then
+	if sbx secret list -g 2>/dev/null | awk '$2 == "github" {exit 0} END {exit 1}'; then
+		: # already set; leave it alone
+	elif gh_token="$(gh auth token 2>/dev/null)" && [[ -n "$gh_token" ]]; then
+		echo ""
+		echo "Setting sbx global secret 'github' from your gh auth token..."
+		echo "  (Lets git push and curl api.github.com work inside cdc sandboxes."
+		echo "   Stored in sbx's host-side proxy — the agent never sees the token.)"
+		if sbx secret set -g github -t "$gh_token" >/dev/null 2>&1; then
+			echo "  ✓ Set sbx global secret: github"
+		else
+			echo "  ⚠️  Failed to set secret. Run manually:"
+			echo "       sbx secret set -g github -t \"\$(gh auth token)\""
+		fi
+		unset gh_token
+	fi
+fi
+
 # --- Done --------------------------------------------------------------------
 
 echo ""


### PR DESCRIPTION
## Summary

Closes #30 alongside the WARN-level doctor check from #31.

Two changes:

### `install.sh` — auto-set the sbx `github` secret

If `gh` is installed and logged in when the installer runs, it calls `sbx secret set -g github -t "$(gh auth token)"` for the user. Skipped if a `github` secret already exists. This closes the discovery gap where new users hit `fatal: could not read Username for 'https://github.com'` on their first `git push` inside a sandbox.

Output:

```
Setting sbx global secret 'github' from your gh auth token...
  (Lets git push and curl api.github.com work inside cdc sandboxes.
   Stored in sbx's host-side proxy — the agent never sees the token.)
  ✓ Set sbx global secret: github
```

Guards:
- Requires both `sbx` and `gh` on PATH.
- No-op if a `github` secret already exists (idempotent re-install).
- Non-empty token check before calling `sbx secret set`.
- Failure prints a manual-recovery line; doesn't fail the installer.

### `README.md` — "GitHub access from the sandbox" section

New section after Updating, explaining:
- Why the sandbox doesn't inherit `gh` auth (sbx uses a proxy, not a filesystem credential).
- That the installer sets this up automatically.
- What works (`git`, `curl` to api.github.com, SSH) vs what doesn't (`gh` CLI itself).
- The `gh pr create` → `curl` workaround with a one-liner.
- The gotcha that global secrets only apply to *new* sandboxes — existing ones need `cdc --cdc-rm`.
- Security note on why we use sbx secrets instead of filesystem injection.

Added to the TOC.

## Test plan

- [ ] Fresh install on a machine with `gh` logged in: installer sets the secret; `cdc --cdc-doctor` shows the OK line.
- [ ] Re-running the installer with the secret already set is a no-op (doesn't overwrite).
- [ ] Installer on a machine without `gh`: skips the step silently, no error.
- [ ] `shellcheck install.sh` + `shfmt -d install.sh` clean.
- [ ] Render README locally; TOC links to the new section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)