### PR TITLE
feat: make gh CLI work inside the sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,18 +518,10 @@ the exact command to run.
 | `git clone/fetch/push` over HTTPS | Yes | Proxy injects the token at the network layer |
 | `curl https://api.github.com/...` | Yes | Same |
 | `git` over SSH (`git@github.com:...`) | Yes | `~/.ssh` is mounted read-only |
-| `gh` CLI (`gh pr create`, `gh issue view`, ...) | **No** | Reads its own token from the host Keychain, which the sandbox can't see |
+| `gh` CLI (`gh pr create`, `gh issue view`, ...) | Yes | `cdc` sets `GH_TOKEN` to a placeholder so `gh` skips its local auth precheck; the proxy rewrites the Authorization header on the wire |
 
-The `gh` CLI gap is rarely a blocker in practice — anything `gh` does, you
-can do with a `curl` against `api.github.com`. Example, creating a PR:
-
-```bash
-curl -sS -X POST https://api.github.com/repos/OWNER/REPO/pulls \
-  -H "Accept: application/vnd.github+json" \
-  -d '{"title":"…","head":"my-branch","base":"main","body":"…"}'
-```
-
-No token header needed — the proxy adds it.
+If the `github` secret isn't set, `gh` and `git push` both fail at the network
+layer — the proxy has no token to inject. Run `cdc --cdc-doctor` to check.
 
 ### Gotcha: global secrets and existing sandboxes
 

--- a/bin/cdc
+++ b/bin/cdc
@@ -541,6 +541,13 @@ build_sbx_argv() {
 	# terminal/color variables into the sandbox. sbx exec does not inherit
 	# the host's TERM/COLORTERM/etc, so without this claude defaults to
 	# minimal/no-color output.
+	#
+	# GH_TOKEN is a placeholder so `gh` CLI skips its local auth precheck.
+	# The sbx proxy rewrites the Authorization header on outbound
+	# api.github.com traffic using the real token from `sbx secret set -g
+	# github`, so the literal value here is never sent on the wire and has
+	# no security implication. Without this, `gh` refuses to run with
+	# "please run gh auth login" even though network-layer auth works.
 	CDC_SBX_ARGV=(
 		sbx exec "$exec_flags" -w "$pwd_abs" "$name"
 		env
@@ -548,6 +555,7 @@ build_sbx_argv() {
 		"COLORTERM=${COLORTERM:-truecolor}"
 		"LANG=${LANG:-en_US.UTF-8}"
 		"LC_ALL=${LC_ALL:-en_US.UTF-8}"
+		"GH_TOKEN=injected-by-sbx-proxy"
 		claude
 	)
 


### PR DESCRIPTION
Closes #33.

## Summary

Add `GH_TOKEN=injected-by-sbx-proxy` to the `env ...` wrapper in `bin/cdc`'s attach argv. `gh` CLI's local precheck sees a non-empty token and proceeds with the request; the sbx proxy rewrites the Authorization header on the wire with the real token from `sbx secret set -g github`. The placeholder value is never sent.

Discovered by empirical testing inside a `cdc` sandbox:

```
$ gh api /user
To get started with GitHub CLI, please run:  gh auth login

$ GH_TOKEN=dummy gh api /user
{"login":"patclarke",...}          # real data — proxy injected real token

$ GH_TOKEN=dummy gh auth status
github.com
  ✓ Logged in to github.com account patclarke (GH_TOKEN)
```

Also updates the README table from #32: `gh` CLI row flips from "No" to "Yes" with a one-line explanation. Drops the now-unneeded `curl api.github.com` workaround paragraph.

## Why this matters for Claude inside the sandbox

Before this change, a Claude agent running inside `cdc` would hit `gh auth login` errors and tell the user "I can't access issue #N — gh CLI isn't authenticated in the sandbox," even though everything it needed to do was reachable via `curl`. Now `gh` just works and the agent never has to reach for the `curl` fallback.

## Security note

The placeholder value (`injected-by-sbx-proxy`) is not sensitive. The sbx proxy replaces it with the real token before the request leaves the host, so an agent that prints `$GH_TOKEN` only captures the literal placeholder string — no credential exposure beyond what already existed (the agent could always make authenticated requests by virtue of being inside the sandbox).

## Test plan

- [x] Verified `GH_TOKEN=dummy gh api /user` returns real user data inside the existing sandbox.
- [x] Verified `gh auth status` with the placeholder correctly reports logged-in state.
- [ ] After merge + symlink update: launch a fresh `cdc` session, confirm `gh issue view 33 --repo patclarke/claude-docker-container` works without any extra env.
- [ ] `shellcheck bin/cdc` + `shfmt -d bin/cdc` clean.
- [ ] `cdc --cdc-doctor` still WARNs when the `github` secret is missing (no regression on #31).

🤖 Generated with [Claude Code](https://claude.com/claude-code)