### PR TITLE
Revert "feat: make gh CLI work inside the sandbox (#34)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,10 +518,18 @@ the exact command to run.
 | `git clone/fetch/push` over HTTPS | Yes | Proxy injects the token at the network layer |
 | `curl https://api.github.com/...` | Yes | Same |
 | `git` over SSH (`git@github.com:...`) | Yes | `~/.ssh` is mounted read-only |
-| `gh` CLI (`gh pr create`, `gh issue view`, ...) | Yes | `cdc` sets `GH_TOKEN` to a placeholder so `gh` skips its local auth precheck; the proxy rewrites the Authorization header on the wire |
+| `gh` CLI (`gh pr create`, `gh issue view`, ...) | **No** | Reads its own token from the host Keychain, which the sandbox can't see |
 
-If the `github` secret isn't set, `gh` and `git push` both fail at the network
-layer — the proxy has no token to inject. Run `cdc --cdc-doctor` to check.
+The `gh` CLI gap is rarely a blocker in practice — anything `gh` does, you
+can do with a `curl` against `api.github.com`. Example, creating a PR:
+
+```bash
+curl -sS -X POST https://api.github.com/repos/OWNER/REPO/pulls \
+  -H "Accept: application/vnd.github+json" \
+  -d '{"title":"…","head":"my-branch","base":"main","body":"…"}'
+```
+
+No token header needed — the proxy adds it.
 
 ### Gotcha: global secrets and existing sandboxes
 

--- a/bin/cdc
+++ b/bin/cdc
@@ -541,13 +541,6 @@ build_sbx_argv() {
 	# terminal/color variables into the sandbox. sbx exec does not inherit
 	# the host's TERM/COLORTERM/etc, so without this claude defaults to
 	# minimal/no-color output.
-	#
-	# GH_TOKEN is a placeholder so `gh` CLI skips its local auth precheck.
-	# The sbx proxy rewrites the Authorization header on outbound
-	# api.github.com traffic using the real token from `sbx secret set -g
-	# github`, so the literal value here is never sent on the wire and has
-	# no security implication. Without this, `gh` refuses to run with
-	# "please run gh auth login" even though network-layer auth works.
 	CDC_SBX_ARGV=(
 		sbx exec "$exec_flags" -w "$pwd_abs" "$name"
 		env
@@ -555,7 +548,6 @@ build_sbx_argv() {
 		"COLORTERM=${COLORTERM:-truecolor}"
 		"LANG=${LANG:-en_US.UTF-8}"
 		"LC_ALL=${LC_ALL:-en_US.UTF-8}"
-		"GH_TOKEN=injected-by-sbx-proxy"
 		claude
 	)
 


### PR DESCRIPTION
Reverts #34. Reopens #33.

## Why

PR #34 added `GH_TOKEN=injected-by-sbx-proxy` to the env wrapper on the assumption that the sbx proxy would rewrite the Authorization header on outbound api.github.com requests. That turned out to be wrong:

**The sbx proxy only *injects* the Authorization header when one is absent. It does not rewrite headers that are already present.**

So setting any `GH_TOKEN` value causes `gh` to send `Authorization: token <placeholder>`, the proxy leaves it alone, and GitHub rejects with `HTTP 401: Bad credentials`. This is exactly what @patclarke hit in a downstream project after merging #34.

## Evidence (reproduced inside a post-#34 sandbox)

```
$ curl -H "Authorization: Bearer fake" https://api.github.com/user
{"message":"Bad credentials","status":"401"}

$ GH_TOKEN=anything gh api /user
{"message":"Bad credentials","status":"401"}

$ unset GH_TOKEN && gh api /user
{"login":"patclarke", ...}
```

With no `GH_TOKEN` in the environment, `gh` sends no Authorization header, the proxy injects the real token, and GitHub returns 200. Every `gh` subcommand tested (`api`, `issue view`, `pr list`, `auth status`) works under this condition — at least when the sandbox was created after the `github` secret was set.

## Earlier test was wrong

My original `GH_TOKEN=dummy gh api /user` test appeared to succeed. On re-examination in a clean sandbox the same invocation returns 401. Likely causes: shell-state bleed between chained commands in the original test output, or a misread of which block's output was which. I should have verified with `GH_DEBUG=api` before shipping.

## After merge

Anyone who launched a `cdc` session between #34 merging and this revert has the broken `GH_TOKEN` baked into their sandbox's attach env. They need to recreate affected sandboxes:

```bash
cdc --cdc-rm
cdc
```

## Follow-up

Reopening #33. The underlying problem it describes (`gh` failing with "please run gh auth login" in some sandboxes) is real, but it does not manifest the way #33 assumed. Need a follow-up investigation with a proper repro of the failure state before attempting another fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)