### PR TITLE
feat(cdc): install guidance CLAUDE.md inside sandbox

### DIFF
--- a/bin/cdc
+++ b/bin/cdc
@@ -515,6 +515,46 @@ setup_share_symlinks() {
 	" </dev/null >/dev/null 2>&1 || true
 }
 
+install_sandbox_notes() {
+	# Write a user-level CLAUDE.md into the sandbox so claude sessions pick up
+	# cdc-specific guidance (GitHub auth via sbx proxy, gh 2.46.0 quirks).
+	# Overwritten on every attach so the guidance stays in sync with the
+	# installed cdc version.
+	local name="$1"
+	sbx exec -i "$name" sh -c 'cat > /home/agent/.claude/CLAUDE.md' <<'NOTES' >/dev/null 2>&1 || true
+# cdc sandbox notes
+
+You are running inside a cdc (claude-docker-container) Docker Sandbox
+microVM. Your host's credentials reach you through sbx's network proxy,
+not through files on disk.
+
+## GitHub access
+
+GitHub auth is injected by the sbx proxy at the network layer when no
+Authorization header is present. The token comes from the host-side
+`sbx secret set -g github` value.
+
+- `git` (HTTPS and SSH), `curl https://api.github.com/...`, and
+  `gh api <endpoint>` all work transparently. Do not run `gh auth login`.
+- If `gh` reports "please run gh auth login" or you see HTTP 401 from
+  GitHub, the fix is host-side. Ask the user to run
+  `sbx secret set -g github -t "$(gh auth token)"` on their Mac, then
+  recreate this sandbox with `cdc --cdc-rm`. Do not try to authenticate
+  from inside the sandbox.
+
+## gh CLI quirks
+
+The baked-in `gh` is 2.46.0, which has a known bug with the deprecated
+`repository.issue.projectCards` GraphQL field. Plain `gh issue view <N>`
+and `gh pr view <N>` exit 1 with only a deprecation warning and no data.
+Use any of these instead — all return full data:
+
+- `gh issue view <N> --json title,body,state,labels,comments`
+- `gh api /repos/OWNER/REPO/issues/<N>`
+- `gh api graphql -f query='...'`
+NOTES
+}
+
 build_sbx_argv() {
 	# Show the attach form that actually runs. We use `sbx exec` instead of
 	# `sbx run` because sbx's agent launcher misbehaves with our credential
@@ -604,6 +644,9 @@ run_sandbox() {
 
 	# Step 3: set up sharing symlinks (idempotent)
 	setup_share_symlinks "$name"
+
+	# Step 3b: install sandbox-specific CLAUDE.md notes (idempotent, overwrites)
+	install_sandbox_notes "$name"
 
 	# sbx race workaround: rapid successive sbx calls leave the sbx daemon in
 	# a state where the next interactive exec is SIGKILL'd at startup (exit 137).


### PR DESCRIPTION
Closes #36.

## Summary

Writes `/home/agent/.claude/CLAUDE.md` on every `cdc` attach so claude sessions inside the sandbox pick up cdc-specific guidance without user intervention.

The guidance covers two concrete failure modes that have tripped up agents in the wild:

1. **GitHub auth** — proxy-injected at the network layer. Tells the agent not to run `gh auth login` inside the sandbox; if it sees a 401 or "please run gh auth login," the fix is host-side (`sbx secret set -g github`).
2. **`gh` 2.46.0 projectCards bug** — plain `gh issue view`/`gh pr view` silently break on the deprecated GraphQL field. Directs the agent to `gh api` or `gh issue view --json` instead.

Both were the direct cause of the failure in #33 and the misdiagnosis chain that led to #34's bad fix and #35's revert.

## Implementation

New function `install_sandbox_notes` in `bin/cdc`, called after `setup_share_symlinks` in the Step 3b slot in the create-and-attach flow. Uses the same `sbx exec -i + heredoc` pattern `cdc` already uses for credential injection. Overwrites on every attach so guidance stays in sync with the installed `cdc` version.

Does **not** touch sbx's pre-existing files (`settings.json`, `backups/`, `downloads/`). Verified empirically before and after.

## Validation

End-to-end test on a fresh sandbox:

```
$ sbx exec cdc-test cat /home/agent/.claude/CLAUDE.md | wc -l
30
$ sbx exec cdc-test ls -la /home/agent/.claude/
... CLAUDE.md ... settings.json ... backups ... downloads
```

- `shellcheck bin/cdc`: clean
- `shfmt -d bin/cdc`: clean
- Idempotent: two consecutive calls leave the file at 30 lines (no duplication)
- Existing sbx files untouched

## Why this and not the symlink approach

The "symlink `~/.config/gh` inside the sandbox" hypothesis I drafted earlier turned out to be wrong — `gh` inside the sandbox works fine without any host config reachable, as long as the `github` secret is set and `gh` doesn't send its own (fake) Authorization header. The real issues were always (a) agents not knowing about the proxy model and (b) the 2.46.0 projectCards bug. This PR addresses both with guidance rather than code paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)