### PR TITLE
refactor: drop Docker Desktop coupling (closes #44)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,12 +49,16 @@ execution.
    removals. Strip ancestor mounts. Compute a deterministic sandbox name from
    cwd. Build the final `sbx` argv.
 3. **Exec.** If the named sandbox doesn't exist, create it with
-   `sbx create claude <primary> <mounts>`. Then inject credentials via
-   `sbx exec -i`. Then create sharing symlinks via `sbx exec`. Finally attach
-   with `sbx exec -it <name> env ... claude <claude-args>` in the foreground
+   `sbx create claude <primary> <mounts>`. If it exists but is stopped (cdc's
+   own post-exit `sbx stop` leaves it that way), bring it back up with
+   `sbx start`. Then inject credentials via `sbx exec -i`. Then create
+   sharing symlinks via `sbx exec`. Finally attach with
+   `sbx exec -it <name> env ... claude <claude-args>` in the foreground
    (not via `exec` — we need to return to cdc after claude exits for cleanup).
-   After claude exits, `cdc` runs `sbx stop` to free the microVM's resources.
-   Pass `--cdc-keep-running` to skip the stop. Propagate sbx's exit code.
+   If that first attach exits 137 (sbx rapid-call race — see lesson 5), retry
+   once after a longer wait. After claude exits, `cdc` runs `sbx stop` to
+   free the microVM's resources. Pass `--cdc-keep-running` to skip the stop.
+   Propagate sbx's exit code.
 
 The `--cdc-dry-run`, `--cdc-doctor`, and `--cdc-no-sandbox` flags short-circuit
 the exec phase in different ways; they still run parse and the relevant parts
@@ -100,8 +104,10 @@ Additional runtime surprises found during implementation:
 5. **sbx rapid-call race:** Running several sbx subcommands back-to-back
    (`create`, `exec` for inject, `exec` for symlinks, final `exec` to
    attach) leaves the sbx daemon in a state where the next interactive
-   exec is SIGKILL'd at startup. A 1-second `sleep` before the final
-   attach avoids this. Worth reporting upstream.
+   exec is SIGKILL'd at startup (exit 137). A 1-second `sleep` before the
+   final attach usually avoids this, but not always — `run_sandbox` also
+   retries the attach once on exit 137 with a longer wait. Worth reporting
+   upstream.
 
 6. **`bash -x` leaks secrets:** The first version of `inject_credentials`
    stored the extracted Keychain token in a shell variable, which
@@ -132,6 +138,9 @@ Key sbx facts that govern the implementation:
   with "sandbox X already exists and can't be given new workspaces". The
   correct flow: `sbx create claude <primary> <mounts>` once, then
   `sbx exec` on every subsequent attach.
+- **Stopped vs. running:** `sbx exec` fails on a stopped sandbox. Since cdc
+  auto-stops after claude exits, every subsequent attach must first check
+  status via `sbx ls` and call `sbx start` if needed.
 
 ## Code style
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,8 +159,8 @@ Key sbx facts that govern the implementation:
 ### What this script deliberately is not
 
 - It is **not a config manager**. Only mount paths are configurable; every
-  other parameter (Docker start timeout, sandbox name hash format, preflight
-  check list) is hardcoded. If something new needs to change, think twice
+  other parameter (sandbox name hash format, preflight check list) is
+  hardcoded. If something new needs to change, think twice
   before moving it to config.
 - It is **not a container orchestrator**. It forwards to `sbx` and lets
   sbx own sandbox lifecycle.
@@ -225,13 +225,9 @@ a PR:
 4. **Worktree sanity.** Run `cdc` from a `.worktrees/feat-foo` directory under
    another repo and confirm the primary mount is the worktree path, not the
    main checkout.
-5. **Failure spot checks.** Exercise both Docker Desktop presence cases:
-   (a) Docker Desktop present + running → quit mid-session, Ctrl-C during the
-   30 s Docker wait, confirm `cdc` surfaces the failure via `sbx` output;
-   (b) Docker Desktop absent entirely (rename `/Applications/Docker.app` or
-   test on a machine without it) → confirm `cdc` proceeds to `sbx` without
-   a Docker-related hard-fail and `--cdc-doctor` shows an `INFO` row.
-   Also: run from a directory outside `~/workspace`.
+5. **Failure spot checks.** Run from a directory outside `~/workspace`; break
+   `sbx` (uninstall or deauthenticate) and confirm its error surfaces cleanly.
+   `cdc` itself does not probe for Docker — `sbx` owns its environment.
 
 Shell lint:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,16 +49,16 @@ execution.
    removals. Strip ancestor mounts. Compute a deterministic sandbox name from
    cwd. Build the final `sbx` argv.
 3. **Exec.** If the named sandbox doesn't exist, create it with
-   `sbx create claude <primary> <mounts>`. If it exists but is stopped (cdc's
-   own post-exit `sbx stop` leaves it that way), bring it back up with
-   `sbx start`. Then inject credentials via `sbx exec -i`. Then create
-   sharing symlinks via `sbx exec`. Finally attach with
-   `sbx exec -it <name> env ... claude <claude-args>` in the foreground
+   `sbx create claude <primary> <mounts>`. Then inject credentials via
+   `sbx exec -i`, create sharing symlinks via `sbx exec`, and finally attach
+   with `sbx exec -it <name> env ... claude <claude-args>` in the foreground
    (not via `exec` — we need to return to cdc after claude exits for cleanup).
-   If that first attach exits 137 (sbx rapid-call race — see lesson 5), retry
-   once after a longer wait. After claude exits, `cdc` runs `sbx stop` to
-   free the microVM's resources. Pass `--cdc-keep-running` to skip the stop.
-   Propagate sbx's exit code.
+   `sbx exec` auto-starts a stopped sandbox (per `sbx exec --help`), so a
+   prior cdc session that ended in `sbx stop` re-attaches transparently — no
+   explicit start step needed. If the first attach exits 137 (sbx rapid-call
+   race — see lesson 5), retry once after a longer wait. After claude exits,
+   `cdc` runs `sbx stop` to free the microVM's resources. Pass
+   `--cdc-keep-running` to skip the stop. Propagate sbx's exit code.
 
 The `--cdc-dry-run`, `--cdc-doctor`, and `--cdc-no-sandbox` flags short-circuit
 the exec phase in different ways; they still run parse and the relevant parts
@@ -138,9 +138,10 @@ Key sbx facts that govern the implementation:
   with "sandbox X already exists and can't be given new workspaces". The
   correct flow: `sbx create claude <primary> <mounts>` once, then
   `sbx exec` on every subsequent attach.
-- **Stopped vs. running:** `sbx exec` fails on a stopped sandbox. Since cdc
-  auto-stops after claude exits, every subsequent attach must first check
-  status via `sbx ls` and call `sbx start` if needed.
+- **Stopped vs. running:** `sbx exec` auto-starts a stopped sandbox before
+  running the command (per `sbx exec --help`). cdc relies on this — the
+  cdc-side post-exit `sbx stop` is for resource cleanup, and the next attach
+  re-starts the sandbox transparently. There is no `sbx start` subcommand.
 
 ## Code style
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,8 +225,13 @@ a PR:
 4. **Worktree sanity.** Run `cdc` from a `.worktrees/feat-foo` directory under
    another repo and confirm the primary mount is the worktree path, not the
    main checkout.
-5. **Failure spot checks.** Quit Docker Desktop mid-session, Ctrl-C during the
-   30 s Docker wait, run from a directory outside `~/workspace`.
+5. **Failure spot checks.** Exercise both Docker Desktop presence cases:
+   (a) Docker Desktop present + running → quit mid-session, Ctrl-C during the
+   30 s Docker wait, confirm `cdc` surfaces the failure via `sbx` output;
+   (b) Docker Desktop absent entirely (rename `/Applications/Docker.app` or
+   test on a machine without it) → confirm `cdc` proceeds to `sbx` without
+   a Docker-related hard-fail and `--cdc-doctor` shows an `INFO` row.
+   Also: run from a directory outside `~/workspace`.
 
 Shell lint:
 

--- a/README.md
+++ b/README.md
@@ -186,11 +186,7 @@ Plugins and skills remain shared read-only; MCP servers are the gap.
 
 ## Quick Install
 
-- `brew install --cask docker` (launch Docker Desktop once so the daemon is running)
 - `brew install docker/tap/sbx && sbx login`
-
-> Docker Desktop is **optional**. `sbx` runs standalone via microVMs on macOS (Apple silicon), Windows 11, and Linux (user must be in the `kvm` group). `cdc` will auto-start Docker Desktop only if it is installed, and will otherwise defer to `sbx`'s own environment checks.
-
 - Install Claude Code: run `claude` and use `/login` (or follow https://claude.ai/claude-code)
 - Install `cdc`: `curl -fsSL https://raw.githubusercontent.com/patclarke/claude-docker-container/main/install.sh | bash`
 
@@ -212,7 +208,7 @@ caffeinate -dims cdc --remote-control --chrome -c
 macOS only for now. Linux may work; I haven't tested it yet. Windows is
 unexplored.
 
-Setup has five steps. First time through takes about 10-15 minutes,
+Setup has four steps. First time through takes about 10 minutes,
 mostly waiting for downloads. After each step there's a one-line command
 you can run to confirm it worked.
 
@@ -222,8 +218,7 @@ You'll need:
 - A Claude account -- sign up at [claude.ai](https://claude.ai) if you
   don't have one (the free tier is enough to get started; `cdc` works with
   any Claude Code tier)
-- About 10 GB of free disk space (most of it is Docker Desktop and the
-  sandbox image)
+- A few GB of free disk space (mostly the sbx sandbox image)
 
 ### Step 1: install Homebrew (if you don't have it yet)
 
@@ -248,35 +243,7 @@ When it finishes, follow its on-screen instructions to add Homebrew to
 your shell. Then open a new terminal window and run `brew --version`
 again to confirm.
 
-### Step 2: install Docker Desktop
-
-Docker Desktop provides the virtualization layer that sandboxes run
-inside. You need it installed and *running* before `cdc` can do anything.
-
-```bash
-brew install --cask docker
-```
-
-Alternative (if you prefer downloading the installer):
-[docker.com/products/docker-desktop](https://www.docker.com/products/docker-desktop/)
-
-After the install finishes, **open Docker Desktop** (from your
-Applications folder or Spotlight). The first launch will ask you to agree
-to its terms, and then you'll see a whale icon appear in your Mac's menu
-bar. Wait for the whale to stop animating -- that means the Docker daemon
-is ready. This usually takes 15-30 seconds.
-
-**Verify:**
-
-```bash
-docker info >/dev/null 2>&1 && echo "OK Docker is running" || echo "FAIL Docker NOT running -- open Docker Desktop from Applications"
-```
-
-If you see `FAIL`, open Docker Desktop and wait for the menu-bar whale to
-settle, then try again. You can quit Docker Desktop anytime you're not
-using `cdc`; `cdc` will auto-start it on the next run if needed.
-
-### Step 3: install Claude Code and log in
+### Step 2: install Claude Code and log in
 
 [Claude Code](https://claude.com/claude-code) is Anthropic's official
 command-line interface for Claude. `cdc` runs it inside the sandbox, but
@@ -319,7 +286,7 @@ You should see output like:
 If `loggedIn` is `false`, run `claude` again and try `/login` inside the
 session.
 
-### Step 4: install sbx (Docker Sandboxes)
+### Step 3: install sbx (Docker Sandboxes)
 
 `sbx` is the command-line tool that creates and manages sandboxes. It's
 maintained by Docker.
@@ -344,7 +311,7 @@ sbx ls
 You should see a "No sandboxes found" message (that's the success case --
 you don't have any sandboxes yet).
 
-### Step 5: install `cdc`
+### Step 4: install `cdc`
 
 `cdc` itself is a single bash script. The easiest way to install it is
 with the one-liner installer, which downloads `cdc` to `~/bin`, detects
@@ -357,7 +324,7 @@ curl -fsSL https://raw.githubusercontent.com/patclarke/claude-docker-container/m
 The installer also runs `cdc --cdc-doctor` at the end as a health check.
 
 **After the install finishes, open a new terminal** so the PATH change
-takes effect, then skip to Step 6.
+takes effect, then skip to Step 5.
 
 <details>
 <summary>Prefer to install manually?</summary>
@@ -389,7 +356,7 @@ Should print: `/Users/<your-username>/bin/cdc`
 
 </details>
 
-### Step 6: final health check
+### Step 5: final health check
 
 If you used the one-liner installer above, the doctor already ran. In a
 **new terminal** (so PATH is updated), verify everything:
@@ -398,13 +365,12 @@ If you used the one-liner installer above, the doctor already ran. In a
 cdc --cdc-doctor
 ```
 
-You should see five green `OK` lines:
+You should see four green `OK` lines:
 
 ```
 cdc doctor
 
   OK    sbx installed
-  OK    Docker Desktop running
   OK    sbx authenticated
   OK    /Users/you/.claude is writable
   OK    claude installed on host (escape hatch available)
@@ -417,12 +383,6 @@ Mount plan (from /Users/you/.config/cdc/mounts.conf):
 
 All checks passed.
 ```
-
-If Docker Desktop isn't running when you run `cdc --cdc-doctor`, it will
-attempt to start it automatically (same as a normal `cdc` invocation) and
-wait up to 30 seconds. If Docker comes up, the check reports OK. If not,
-it reports FAIL and continues with the remaining checks so you still see
-the full picture.
 
 If anything is `FAIL`, the doctor prints exactly which step you need to
 revisit. The first time you run `cdc --cdc-doctor`, it creates
@@ -442,14 +402,6 @@ something.
 
 **`brew: command not found`** -- you skipped Step 1. Install Homebrew,
 then open a new terminal.
-
-**`docker: command not found` after installing Docker Desktop** --
-Docker Desktop's CLI tools aren't on PATH yet. Close and reopen your
-terminal, then try `docker info` again.
-
-**Docker Desktop won't start** -- quit it (right-click the whale icon ->
-Quit), open Activity Monitor, force-quit any `Docker` or `com.docker.*`
-processes, and relaunch Docker Desktop from Applications.
 
 **`sbx login` opens a browser but I don't have a Docker Hub account** --
 you can create one for free at
@@ -586,8 +538,8 @@ to your session history and plugins.
 
 On every invocation, `cdc` does this:
 
-1. **Preflight.** Check that `sbx` is installed, Docker Desktop is running
-   (auto-start if not), `sbx` is authenticated, and `~/.claude` is writable.
+1. **Preflight.** Check that `sbx` is installed, `sbx` is authenticated, and
+   `~/.claude` is writable. `sbx` surfaces any environment issues of its own.
 2. **Plan.** Load mounts from `~/.config/cdc/mounts.conf`, apply `--cdc-mount`
    and `--cdc-no-mount` overrides, drop any mount whose path is missing, and
    strip any mount that's an ancestor of your current working directory
@@ -821,8 +773,7 @@ Linux: probably, with tweaks. The Keychain extraction step is macOS-specific
 file at `~/.claude/.credentials.json`; `cdc` would need a code path that
 reads that file instead of calling `security`. PRs welcome.
 
-Windows: untested and unplanned. Would require Docker Desktop for Windows
-and a different credential flow.
+Windows: untested and unplanned. Would require a different credential flow.
 
 **Can I use this with non-Claude agents (Codex, Gemini, etc.)?**
 

--- a/README.md
+++ b/README.md
@@ -188,6 +188,9 @@ Plugins and skills remain shared read-only; MCP servers are the gap.
 
 - `brew install --cask docker` (launch Docker Desktop once so the daemon is running)
 - `brew install docker/tap/sbx && sbx login`
+
+> Docker Desktop is **optional**. `sbx` runs standalone via microVMs on macOS (Apple silicon), Windows 11, and Linux (user must be in the `kvm` group). `cdc` will auto-start Docker Desktop only if it is installed, and will otherwise defer to `sbx`'s own environment checks.
+
 - Install Claude Code: run `claude` and use `/login` (or follow https://claude.ai/claude-code)
 - Install `cdc`: `curl -fsSL https://raw.githubusercontent.com/patclarke/claude-docker-container/main/install.sh | bash`
 

--- a/bin/cdc
+++ b/bin/cdc
@@ -170,30 +170,32 @@ run_doctor() {
 		fails=$((fails + 1))
 	fi
 
-	# Auto-start Docker if it's not running, same as the normal cdc exec path.
-	# Unlike ensure_docker_running (which calls die on failure), this inline
-	# version continues to the remaining checks so doctor always reports the
-	# full picture.
-	if ! docker info >/dev/null 2>&1; then
-		echo "  Docker Desktop is not running. Attempting to start it..." >&2
-		open -a Docker 2>/dev/null || true
-		local docker_waited=0
-		while ((docker_waited < 30)); do
-			if docker info >/dev/null 2>&1; then
-				break
-			fi
-			sleep 1
-			docker_waited=$((docker_waited + 1))
-			printf '.' >&2
-		done
-		[[ $docker_waited -gt 0 ]] && echo >&2
-	fi
-
-	if preflight_docker; then
-		print_check OK "Docker Desktop running"
+	# Docker Desktop is optional. If the app is installed, try to bring it up
+	# and report OK/FAIL. If it is absent, report INFO — sbx supports
+	# standalone microVMs on Apple silicon, Windows, and Linux.
+	if docker_desktop_installed; then
+		if ! docker info >/dev/null 2>&1; then
+			echo "  Docker Desktop is not running. Attempting to start it..." >&2
+			open -a Docker 2>/dev/null || true
+			local docker_waited=0
+			while ((docker_waited < 30)); do
+				if docker info >/dev/null 2>&1; then
+					break
+				fi
+				sleep 1
+				docker_waited=$((docker_waited + 1))
+				printf '.' >&2
+			done
+			[[ $docker_waited -gt 0 ]] && echo >&2
+		fi
+		if docker info >/dev/null 2>&1 && docker ps >/dev/null 2>&1; then
+			print_check OK "Docker Desktop running"
+		else
+			print_check FAIL "Docker Desktop running    (could not start within 30s)"
+			fails=$((fails + 1))
+		fi
 	else
-		print_check FAIL "Docker Desktop running    (could not start within 30s)"
-		fails=$((fails + 1))
+		print_check INFO "Docker Desktop not installed    (sbx runs standalone; this is fine)"
 	fi
 
 	if preflight_sbx_auth; then

--- a/bin/cdc
+++ b/bin/cdc
@@ -82,6 +82,12 @@ ensure_docker_running() {
 	if docker info >/dev/null 2>&1; then
 		return 0
 	fi
+	# Docker Desktop is a macOS-only concept and is optional: sbx runs
+	# standalone on Apple silicon, Windows, and Linux. If the app isn't
+	# installed, skip silently and let sbx surface its own errors.
+	if ! docker_desktop_installed; then
+		return 0
+	fi
 	echo "cdc: Docker Desktop is not running. Starting it..." >&2
 	open -a Docker 2>/dev/null || die "failed to launch Docker Desktop."
 	local waited=0
@@ -95,7 +101,11 @@ ensure_docker_running() {
 		printf '.' >&2
 	done
 	echo >&2
-	die "Docker Desktop failed to start within 30s."
+	# Even if the 30s wait expires, don't die — sbx may still succeed without
+	# a running Docker Desktop (it uses virtualization framework directly on
+	# Apple silicon). Just warn and continue.
+	echo "cdc: Docker Desktop did not start within 30s; continuing (sbx may still work)." >&2
+	return 0
 }
 
 run_preflight() {

--- a/bin/cdc
+++ b/bin/cdc
@@ -413,6 +413,30 @@ sandbox_exists() {
 	sbx ls 2>/dev/null | awk 'NR>1 {print $1}' | grep -qx "$name"
 }
 
+sandbox_status() {
+	# Prints the STATUS column for a sandbox (running | stopped | ""), stripping
+	# ANSI color codes sbx emits (e.g. "\033[32mrunning\033[0m"). Empty output
+	# means the sandbox does not exist.
+	local name="$1"
+	sbx ls 2>/dev/null |
+		awk -v n="$name" 'NR>1 && $1 == n {print $3}' |
+		sed -E 's/\x1b\[[0-9;]*m//g'
+}
+
+ensure_sandbox_running() {
+	# `sbx exec` on a stopped sandbox fails. If the sandbox exists but is
+	# stopped (e.g. cdc's own post-exit `sbx stop` from the previous run), bring
+	# it back up before injecting credentials and attaching.
+	local name="$1"
+	if [[ "$(sandbox_status "$name")" != "stopped" ]]; then
+		return 0
+	fi
+	sbx start "$name" >/dev/null 2>&1 || {
+		echo "cdc: failed to start existing sandbox $name" >&2
+		return 1
+	}
+}
+
 inject_credentials() {
 	local name="$1"
 	# SECURITY: never assign the token to a shell variable — `bash -x` would
@@ -571,7 +595,8 @@ run_sandbox() {
 	local name
 	name="$(compute_sandbox_name)"
 
-	# Step 1: create sandbox if it doesn't exist yet
+	# Step 1: ensure the sandbox exists and is running. Create it if new; start
+	# it if a previous cdc run (or manual `sbx stop`) left it stopped.
 	if ! sandbox_exists "$name"; then
 		local create_argv=()
 		build_create_argv
@@ -580,6 +605,8 @@ run_sandbox() {
 			echo "cdc: failed to create sandbox $name" >&2
 			return 1
 		}
+	else
+		ensure_sandbox_running "$name" || return 1
 	fi
 
 	# Step 2: inject credentials (idempotent, refreshes token each run)
@@ -593,12 +620,12 @@ run_sandbox() {
 
 	# sbx race workaround: rapid successive sbx calls leave the sbx daemon in
 	# a state where the next interactive exec is SIGKILL'd at startup (exit 137).
-	# A brief pause before the attach lets the daemon settle.
+	# A brief pause before the attach lets the daemon settle; on the rare
+	# occasion the pause isn't enough, retry once with a longer wait.
 	sleep 1
 
 	# Step 4: run claude in the foreground. We use a foreground call (not exec)
-	# so we can run cleanup (sbx stop) after claude exits. The sleep above
-	# handles the 137 race that originally motivated the exec.
+	# so we can run cleanup (sbx stop) after claude exits.
 	local rc=0
 
 	# Register cleanup trap so sandbox stops even on Ctrl-C / SIGTERM
@@ -606,7 +633,19 @@ run_sandbox() {
 		trap 'sbx stop "$name" >/dev/null 2>&1 || true; exit 130' INT TERM
 	fi
 
-	"${CDC_SBX_ARGV[@]}" || rc=$?
+	local attempt
+	for attempt in 1 2; do
+		rc=0
+		"${CDC_SBX_ARGV[@]}" || rc=$?
+		# 137 on the very first exec is the documented sbx rapid-call race.
+		# Anything else (including a 137 from the user killing claude later)
+		# is a real exit and should propagate.
+		if [[ $rc -ne 137 || $attempt -eq 2 ]]; then
+			break
+		fi
+		echo "cdc: sbx exec exited 137 (daemon race); retrying after short wait..." >&2
+		sleep 3
+	done
 
 	# Clean up trap
 	trap - INT TERM

--- a/bin/cdc
+++ b/bin/cdc
@@ -18,13 +18,6 @@ preflight_sbx() {
 	command -v sbx >/dev/null 2>&1
 }
 
-docker_desktop_installed() {
-	# Docker Desktop ships as /Applications/Docker.app on macOS. On Linux and
-	# Windows the concept doesn't apply; return false so callers skip the
-	# macOS-specific auto-start path.
-	[[ "$(uname -s)" == "Darwin" && -d "/Applications/Docker.app" ]]
-}
-
 preflight_sbx_auth() {
 	sbx ls >/dev/null 2>&1
 }
@@ -71,43 +64,12 @@ EOF
 	exit 1
 }
 
-ensure_docker_running() {
-	if docker info >/dev/null 2>&1; then
-		return 0
-	fi
-	# Docker Desktop is a macOS-only concept and is optional: sbx runs
-	# standalone on Apple silicon, Windows, and Linux. If the app isn't
-	# installed, skip silently and let sbx surface its own errors.
-	if ! docker_desktop_installed; then
-		return 0
-	fi
-	echo "cdc: Docker Desktop is not running. Starting it..." >&2
-	open -a Docker 2>/dev/null || die "failed to launch Docker Desktop."
-	local waited=0
-	while ((waited < 30)); do
-		if docker info >/dev/null 2>&1; then
-			echo >&2
-			return 0
-		fi
-		sleep 1
-		waited=$((waited + 1))
-		printf '.' >&2
-	done
-	echo >&2
-	# Even if the 30s wait expires, don't die — sbx may still succeed without
-	# a running Docker Desktop (it uses virtualization framework directly on
-	# Apple silicon). Just warn and continue.
-	echo "cdc: Docker Desktop did not start within 30s; continuing (sbx may still work)." >&2
-	return 0
-}
-
 run_preflight() {
 	if [[ $CDC_NO_SANDBOX -eq 1 ]]; then
 		preflight_claude_binary || die_preflight claude_binary
 		return 0
 	fi
 	preflight_sbx || die_preflight sbx
-	ensure_docker_running
 	preflight_sbx_auth || die_preflight sbx_auth
 	preflight_claude_dir || die_preflight claude_dir
 	return 0
@@ -117,7 +79,6 @@ print_check() {
 	local state="$1" label="$2"
 	case "$state" in
 	OK) printf '  \033[32mOK\033[0m    %s\n' "$label" ;;
-	INFO) printf '  \033[36mINFO\033[0m  %s\n' "$label" ;;
 	WARN) printf '  \033[33mWARN\033[0m  %s\n' "$label" ;;
 	FAIL) printf '  \033[31mFAIL\033[0m  %s\n' "$label" ;;
 	esac
@@ -125,7 +86,6 @@ print_check() {
 
 run_ls() {
 	preflight_sbx || die_preflight sbx
-	ensure_docker_running
 	preflight_sbx_auth || die_preflight sbx_auth
 	echo "# active sbx sandboxes"
 	sbx ls
@@ -133,7 +93,6 @@ run_ls() {
 
 run_rm() {
 	preflight_sbx || die_preflight sbx
-	ensure_docker_running
 	preflight_sbx_auth || die_preflight sbx_auth
 
 	local target
@@ -168,34 +127,6 @@ run_doctor() {
 	else
 		print_check FAIL "sbx installed    (brew install docker/tap/sbx)"
 		fails=$((fails + 1))
-	fi
-
-	# Docker Desktop is optional. If the app is installed, try to bring it up
-	# and report OK/FAIL. If it is absent, report INFO — sbx supports
-	# standalone microVMs on Apple silicon, Windows, and Linux.
-	if docker_desktop_installed; then
-		if ! docker info >/dev/null 2>&1; then
-			echo "  Docker Desktop is not running. Attempting to start it..." >&2
-			open -a Docker 2>/dev/null || true
-			local docker_waited=0
-			while ((docker_waited < 30)); do
-				if docker info >/dev/null 2>&1; then
-					break
-				fi
-				sleep 1
-				docker_waited=$((docker_waited + 1))
-				printf '.' >&2
-			done
-			[[ $docker_waited -gt 0 ]] && echo >&2
-		fi
-		if docker info >/dev/null 2>&1 && docker ps >/dev/null 2>&1; then
-			print_check OK "Docker Desktop running"
-		else
-			print_check FAIL "Docker Desktop running    (could not start within 30s)"
-			fails=$((fails + 1))
-		fi
-	else
-		print_check INFO "Docker Desktop not installed    (sbx runs standalone; this is fine)"
 	fi
 
 	if preflight_sbx_auth; then

--- a/bin/cdc
+++ b/bin/cdc
@@ -413,6 +413,35 @@ sandbox_exists() {
 	sbx ls 2>/dev/null | awk 'NR>1 {print $1}' | grep -qx "$name"
 }
 
+CDC_SPINNER_PID=""
+
+spinner_start() {
+	# Animated single-line spinner on stderr so the user sees cdc making
+	# progress during the otherwise-silent inject+symlink+sleep phase between
+	# `sbx create` and the foreground `sbx exec` attach. No-op when stderr
+	# isn't a TTY (CI, piped output) — a spinner there is just noise.
+	[[ -t 2 ]] || return 0
+	local msg="$1"
+	(
+		local frames='-\|/'
+		local i=0
+		trap 'printf "\r\033[K" >&2; exit 0' TERM
+		while :; do
+			printf '\r%s %s' "${frames:i++%4:1}" "$msg" >&2
+			sleep 0.15
+		done
+	) &
+	CDC_SPINNER_PID=$!
+}
+
+spinner_stop() {
+	[[ -n "$CDC_SPINNER_PID" ]] || return 0
+	kill "$CDC_SPINNER_PID" 2>/dev/null || true
+	wait "$CDC_SPINNER_PID" 2>/dev/null || true
+	printf '\r\033[K' >&2
+	CDC_SPINNER_PID=""
+}
+
 inject_credentials() {
 	local name="$1"
 	# SECURITY: never assign the token to a shell variable — `bash -x` would
@@ -586,8 +615,11 @@ run_sandbox() {
 
 	# Tell the user cdc is still driving — `sbx create` ends by printing
 	# "To connect to this sandbox, run: sbx run <name>", which looks like an
-	# instruction but isn't (cdc is about to attach automatically).
-	echo "cdc: connecting claude to sandbox $name..." >&2
+	# instruction but isn't (cdc is about to attach automatically). The
+	# spinner runs through the silent prep phase so a slow inject doesn't
+	# look like a freeze; it's stopped before the foreground sbx exec so it
+	# doesn't fight sbx's own output.
+	spinner_start "connecting claude to sandbox $name"
 
 	# Step 2: inject credentials (idempotent, refreshes token each run)
 	inject_credentials "$name"
@@ -603,6 +635,7 @@ run_sandbox() {
 	# A brief pause before the attach lets the daemon settle; on the rare
 	# occasion the pause isn't enough, retry once with a longer wait.
 	sleep 1
+	spinner_stop
 
 	# Step 4: run claude in the foreground. We use a foreground call (not exec)
 	# so we can run cleanup (sbx stop) after claude exits.

--- a/bin/cdc
+++ b/bin/cdc
@@ -609,6 +609,11 @@ run_sandbox() {
 		ensure_sandbox_running "$name" || return 1
 	fi
 
+	# Tell the user cdc is still driving — `sbx create` ends by printing
+	# "To connect to this sandbox, run: sbx run <name>", which looks like an
+	# instruction but isn't (cdc is about to attach automatically).
+	echo "cdc: connecting claude to sandbox $name..." >&2
+
 	# Step 2: inject credentials (idempotent, refreshes token each run)
 	inject_credentials "$name"
 

--- a/bin/cdc
+++ b/bin/cdc
@@ -413,30 +413,6 @@ sandbox_exists() {
 	sbx ls 2>/dev/null | awk 'NR>1 {print $1}' | grep -qx "$name"
 }
 
-sandbox_status() {
-	# Prints the STATUS column for a sandbox (running | stopped | ""), stripping
-	# ANSI color codes sbx emits (e.g. "\033[32mrunning\033[0m"). Empty output
-	# means the sandbox does not exist.
-	local name="$1"
-	sbx ls 2>/dev/null |
-		awk -v n="$name" 'NR>1 && $1 == n {print $3}' |
-		sed -E 's/\x1b\[[0-9;]*m//g'
-}
-
-ensure_sandbox_running() {
-	# `sbx exec` on a stopped sandbox fails. If the sandbox exists but is
-	# stopped (e.g. cdc's own post-exit `sbx stop` from the previous run), bring
-	# it back up before injecting credentials and attaching.
-	local name="$1"
-	if [[ "$(sandbox_status "$name")" != "stopped" ]]; then
-		return 0
-	fi
-	sbx start "$name" >/dev/null 2>&1 || {
-		echo "cdc: failed to start existing sandbox $name" >&2
-		return 1
-	}
-}
-
 inject_credentials() {
 	local name="$1"
 	# SECURITY: never assign the token to a shell variable — `bash -x` would
@@ -595,8 +571,9 @@ run_sandbox() {
 	local name
 	name="$(compute_sandbox_name)"
 
-	# Step 1: ensure the sandbox exists and is running. Create it if new; start
-	# it if a previous cdc run (or manual `sbx stop`) left it stopped.
+	# Step 1: create the sandbox if it doesn't exist yet. If it exists but is
+	# stopped (cdc's own post-exit `sbx stop` leaves it that way), `sbx exec`
+	# below will auto-start it — that's documented in `sbx exec --help`.
 	if ! sandbox_exists "$name"; then
 		local create_argv=()
 		build_create_argv
@@ -605,8 +582,6 @@ run_sandbox() {
 			echo "cdc: failed to create sandbox $name" >&2
 			return 1
 		}
-	else
-		ensure_sandbox_running "$name" || return 1
 	fi
 
 	# Tell the user cdc is still driving — `sbx create` ends by printing

--- a/bin/cdc
+++ b/bin/cdc
@@ -22,6 +22,13 @@ preflight_docker() {
 	docker info >/dev/null 2>&1 && docker ps >/dev/null 2>&1
 }
 
+docker_desktop_installed() {
+	# Docker Desktop ships as /Applications/Docker.app on macOS. On Linux and
+	# Windows the concept doesn't apply; return false so callers skip the
+	# macOS-specific auto-start path.
+	[[ "$(uname -s)" == "Darwin" && -d "/Applications/Docker.app" ]]
+}
+
 preflight_sbx_auth() {
 	sbx ls >/dev/null 2>&1
 }
@@ -108,6 +115,7 @@ print_check() {
 	local state="$1" label="$2"
 	case "$state" in
 	OK) printf '  \033[32mOK\033[0m    %s\n' "$label" ;;
+	INFO) printf '  \033[36mINFO\033[0m  %s\n' "$label" ;;
 	WARN) printf '  \033[33mWARN\033[0m  %s\n' "$label" ;;
 	FAIL) printf '  \033[31mFAIL\033[0m  %s\n' "$label" ;;
 	esac

--- a/bin/cdc
+++ b/bin/cdc
@@ -18,10 +18,6 @@ preflight_sbx() {
 	command -v sbx >/dev/null 2>&1
 }
 
-preflight_docker() {
-	docker info >/dev/null 2>&1 && docker ps >/dev/null 2>&1
-}
-
 docker_desktop_installed() {
 	# Docker Desktop ships as /Applications/Docker.app on macOS. On Linux and
 	# Windows the concept doesn't apply; return false so callers skip the
@@ -61,9 +57,6 @@ cdc: sbx not found on PATH.
     Install:   brew install docker/tap/sbx
     Then run:  sbx login
 EOF
-		;;
-	docker)
-		echo "cdc: Docker Desktop is not responding. Run 'docker info' to debug." >&2
 		;;
 	sbx_auth)
 		echo "cdc: sbx is not authenticated. Run: sbx login" >&2
@@ -115,7 +108,6 @@ run_preflight() {
 	fi
 	preflight_sbx || die_preflight sbx
 	ensure_docker_running
-	preflight_docker || die_preflight docker
 	preflight_sbx_auth || die_preflight sbx_auth
 	preflight_claude_dir || die_preflight claude_dir
 	return 0

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,6 @@
 # cdc installer — downloads bin/cdc and sets up PATH.
 #
 # Prerequisites (not handled by this script):
-#   - Docker Desktop:  brew install --cask docker
 #   - Claude Code:     https://claude.com/claude-code
 #   - sbx:             brew install docker/tap/sbx && sbx login
 #
@@ -130,7 +129,6 @@ echo ""
 echo "  Or just open a new terminal — PATH will be set automatically."
 echo ""
 echo "Prerequisites not handled by this script:"
-echo "  - Docker Desktop:  brew install --cask docker"
 echo "  - Claude Code:     https://claude.com/claude-code"
 echo "  - sbx:             brew install docker/tap/sbx && sbx login"
 echo ""


### PR DESCRIPTION
## Summary

Drops all Docker Desktop coupling from `cdc` (issue #44) and fixes the latent attach bugs that the decoupling exposed.

### Docker Desktop decoupling (closes #44)
- Delete `preflight_docker`, `docker_desktop_installed`, `ensure_docker_running`, the `docker` branch of `die_preflight`, and the `INFO` state from `print_check` (no remaining users).
- Remove the Docker Desktop block from `--cdc-doctor`; doctor now reports four rows: sbx installed, sbx authenticated, `~/.claude` writable, claude on host.
- **README:** drop `brew install --cask docker` from Quick Install; delete "Step 2: install Docker Desktop" and renumber (5 → 4); remove Docker Desktop rows from the doctor example, the "How it works" preflight, troubleshooting, and the Windows FAQ.
- **install.sh:** remove Docker Desktop from prerequisite lists.
- **CLAUDE.md:** simplify validation item 5; drop "Docker start timeout" from the config-manager scope note.

### Attach bugs surfaced by the decoupling
Without the 30 s Docker auto-start path, `sbx`'s `create → exec` timing got tighter and these reliably broke:

1. **sbx rapid-call SIGKILL race.** The documented `sleep 1` before the final attach is no longer always enough — first `sbx exec -it … claude` exits 137 and `cdc` quietly returned to the prompt. **Fix:** wrap the attach in a 2-attempt loop that retries only on 137, with a 3 s wait between.
2. **Stopped sandbox re-attach.** A previous `cdc` run's post-exit `sbx stop` left the sandbox stopped; the next attach silently failed for the same race reason. **Fix:** the 137 retry covers this too — `sbx exec` itself auto-starts a stopped sandbox (per `sbx exec --help`), so no explicit start step is needed.

### UX polish
- After `sbx create`, print `cdc: connecting claude to sandbox <name>...` so the sbx-emitted "To connect to this sandbox, run: sbx run …" line isn't mistaken for an instruction the user has to follow.
- Animated single-line spinner during the silent inject + symlink + settle phase before the foreground attach, so the few-second gap doesn't look like a freeze. No-op when stderr isn't a TTY.

CLAUDE.md updated to record corrected sbx behavior (`sbx exec` auto-starts stopped sandboxes; there is no `sbx start` subcommand) and the retry-on-137 strategy.

## Diff
`4 files changed, +88 / -130`. 11 commits — feel free to **Squash and merge**.

## Test plan
- [x] `cdc --cdc-doctor` shows four `OK` rows; no Docker row regardless of Docker Desktop state.
- [x] `cdc` from a fresh cwd: creates sandbox, attaches claude UI on the first try (or retries once after `cdc: sbx exec exited 137 (daemon race)…` and attaches).
- [x] Exit claude; rerun `cdc` from the same cwd: re-attaches cleanly via `sbx exec`'s built-in auto-start.
- [x] Spinner animates during the silent prep phase and clears before sbx output begins.
- [x] `shellcheck bin/cdc install.sh` clean.
- [x] `shfmt -d bin/cdc install.sh` clean.

Closes #44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
