### PR TITLE
docs: AWS credential handling recipes (closes #42)

### DIFF
--- a/README.md
+++ b/README.md
@@ -622,6 +622,39 @@ user-level `~/.claude/CLAUDE.md` is not shared. Project-level `CLAUDE.md` in
 | `~/.aws`                | RO   | Credentials readable by agent; **see credential scoping above** |
 | `~/.ssh`                | RO   | git over ssh; **see credential scoping above**                  |
 
+### AWS credential handling
+
+Unlike the GitHub case, the sbx `aws` secret alone doesn't cover every
+AWS workflow. Which credential path you use decides whether `~/.aws:ro`
+needs to stay mounted.
+
+| Access pattern     | Works with `sbx secret set -g aws` alone? | Why                                                                    |
+|--------------------|-------------------------------------------|------------------------------------------------------------------------|
+| Static access keys | Yes                                       | No client-side logic: the proxy injects the `Authorization` header     |
+| Named profiles     | No                                        | CLI reads `~/.aws/config` to resolve the profile before any HTTP call  |
+| Assume-role        | No                                        | CLI reads `role_arn` from `~/.aws/config` and caches STS output on disk|
+| AWS SSO            | No                                        | `aws sso login` needs a browser and writes token cache to `~/.aws/sso/`|
+
+**Default (all patterns):** keep `~/.aws:ro` mounted — this is the
+default, no action needed. Trade-off: a runaway agent can read the raw
+credential file.
+
+**Static-keys-only, tighter scoping:** on the host, run
+
+    sbx secret set -g aws
+
+Paste your access key and secret when prompted (or pipe from stdin per
+`sbx secret set --help`). Then launch cdc with the mount suppressed:
+
+    cdc --cdc-no-mount ~/.aws
+
+Raw credentials never cross the VM boundary; the proxy injects auth on
+outbound AWS API calls.
+
+**SSO users:** keep `~/.aws:ro` mounted. `aws sso login` opens a
+browser and writes a token cache to `~/.aws/sso/`, neither of which
+the proxy handles.
+
 ### Customizing
 
 Permanent changes: edit `~/.config/cdc/mounts.conf`. One line per mount,


### PR DESCRIPTION
## Summary

Adds an "AWS credential handling" subsection to `README.md` explaining — per access pattern — whether the sbx `aws` global secret alone covers the workflow or whether the `~/.aws:ro` mount is needed. Includes a copy-paste recipe for static-keys-only users who want tighter credential scoping via `sbx secret set -g aws` + `cdc --cdc-no-mount ~/.aws`.

## What doesn't change
- Default `mounts.conf` still includes `~/.aws:ro` — all existing AWS workflows keep working.
- `bin/cdc` is untouched.
- Existing README mentions of `~/.aws` are all still accurate and unchanged.

## Scope choice
Issue #42 suggested three actions: (1) investigate, (2) document, (3) optionally drop the default mount. This PR is (2) only. Named profiles, assume-role, and SSO all rely on the AWS CLI reading `~/.aws` content before any HTTP call reaches the proxy, so the secret alone can't cover them.

Closes #42.