### PR TITLE
docs: clarify --chrome unsupported in sandbox (closes #28)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ On top of sbx, `cdc` adds the bits you'd otherwise have to do by hand:
 You keep typing the same `claude ...` commands you're used to. You just type
 `cdc` instead. Example:
 ```
-claude --remote-control --chrome   # normal
-cdc --remote-control --chrome      # sandboxed
+claude --remote-control   # normal
+cdc --remote-control      # sandboxed
 ```
 
 ## What `cdc` guarantees
@@ -155,6 +155,20 @@ sandbox can read and write. If your project contains `.env` files with
 secrets, a deploy key, or other sensitive files, the sandbox sees them.
 Don't commit secrets into your project and also don't mount them into it.
 
+### `claude --chrome` is not supported inside the sandbox
+
+Claude's Chrome integration uses Chrome's **native messaging** protocol —
+Chrome spawns a helper binary on the host and communicates via stdio pipes,
+plus a host-side unix domain socket (`/tmp/claude-mcp-browser-bridge-<user>/`)
+for IPC between claude sessions. Neither mechanism crosses the sbx
+microVM boundary: Chrome cannot spawn processes inside a Linux VM from
+macOS, and unix sockets do not work across kernel boundaries.
+
+If you want Chrome integration, run `claude --chrome` directly on the
+host (outside cdc), or use `cdc --cdc-no-sandbox --chrome`. Note that
+`--cdc-no-sandbox` skips the sandbox entirely — you lose the safety
+boundary that cdc provides.
+
 ### `cdc --cdc-no-sandbox` bypasses everything
 
 The escape hatch runs plain `claude` on your host with the forwarded args.
@@ -195,12 +209,12 @@ Details, verification commands, and alternatives live in [Install](#install).
 ## Quick Use
 
 ```bash
-caffeinate -dims cdc --remote-control --chrome -c
+caffeinate -dims cdc --remote-control -c
 ```
 
 - `cdc` launches Claude inside a sandbox for the current directory
 - `caffeinate -dims` keeps macOS awake while the sandbox runs
-- `--remote-control --chrome -c` are standard Claude flags; everything non-`--cdc-*` passes through
+- `--remote-control -c` are standard Claude flags; everything non-`--cdc-*` passes through
 - More examples and flags: see [Quick start](#quick-start) and [Reference](#reference)
 
 ## Install
@@ -394,6 +408,11 @@ that just means the host `claude` binary is missing, so the
 it uses the claude that lives inside the sandbox. Fix it by revisiting
 Step 3 if you want the escape hatch.
 
+**"Claude in Chrome (Beta)" prompt appears inside cdc but nothing works.**
+Chrome integration relies on host-only APIs (native messaging + unix
+sockets) that don't reach the sandbox. Use `cdc --cdc-no-sandbox --chrome`
+or run host `claude --chrome` directly.
+
 **Anything else** -- open an issue at
 [github.com/patclarke/claude-docker-container/issues](https://github.com/patclarke/claude-docker-container/issues)
 with the output of `cdc --cdc-doctor` and I'll take a look.
@@ -494,14 +513,14 @@ switch to fine-grained GitHub tokens if that's a concern. See
 
 ```bash
 cd ~/workspace/my-project
-caffeinate -dims cdc --remote-control --chrome -c
+caffeinate -dims cdc --remote-control -c
 ```
 
 Breakdown:
 
 - `caffeinate -dims` -- keep your Mac awake while the session runs
 - `cdc` -- launch Claude Code inside a sandbox for this directory
-- `--remote-control --chrome -c` -- regular Claude Code flags, passed through
+- `--remote-control -c` -- regular Claude Code flags, passed through
   to the agent inside the sandbox
 
 First invocation in a new directory is slow -- sbx downloads the sandbox
@@ -683,7 +702,7 @@ cdc
 cdc -c
 
 # Forward arbitrary Claude Code flags
-cdc --remote-control --chrome -c
+cdc --remote-control -c
 
 # Two parallel sandboxes in the same directory
 cdc --cdc-name experiment-a -c

--- a/bin/cdc
+++ b/bin/cdc
@@ -733,6 +733,24 @@ parse_args() {
 	done
 }
 
+warn_if_chrome_requested() {
+	# --chrome (Chrome integration) uses Chrome native messaging, which is
+	# structurally incompatible with the sandbox — Chrome can't spawn
+	# processes inside a VM, and the host unix socket it uses isn't
+	# reachable across kernel boundaries. The feature will prompt for
+	# setup but then silently fail to connect. See README "claude --chrome
+	# is not supported inside the sandbox."
+	local arg
+	for arg in "${CLAUDE_ARGS[@]+"${CLAUDE_ARGS[@]}"}"; do
+		if [[ "$arg" == "--chrome" ]]; then
+			echo "cdc: warning: --chrome is not supported inside the sandbox." >&2
+			echo "     Chrome integration uses host-only APIs (native messaging)." >&2
+			echo "     Use 'cdc --cdc-no-sandbox --chrome' or host 'claude --chrome'." >&2
+			return 0
+		fi
+	done
+}
+
 dry_run_output() {
 	load_mounts_config
 	resolve_mounts
@@ -790,6 +808,7 @@ main() {
 		exec claude "${CLAUDE_ARGS[@]+"${CLAUDE_ARGS[@]}"}"
 	fi
 
+	warn_if_chrome_requested
 	ensure_github_secret
 	load_mounts_config
 	resolve_mounts


### PR DESCRIPTION
## Summary

Closes #28.

Investigation proved Claude's `--chrome` feature uses Chrome native messaging + a host unix socket — both structurally incompatible with sbx's VM isolation:

- Chrome spawns `claude --chrome-native-host` on the host via `fork()`+`exec()`. Cannot cross the Linux VM boundary.
- IPC to other claude sessions is via `/tmp/claude-mcp-browser-bridge-<user>/<pid>.sock` — a host unix socket. Cannot be `connect()`ed from the sandbox's Linux kernel even if the directory is bind-mounted.

No sbx configuration (port-publish, `host.docker.internal`, env vars) can bridge this.

### Evidence

- Native messaging host manifest: `~/Library/Application Support/Google/Chrome/NativeMessagingHosts/com.anthropic.claude_code_browser_extension.json` declares `"type": "stdio"` with `"path": "/Users/pat/.claude/chrome/chrome-native-host"`, allowed origin = Chrome extension ID.
- Running process: `claude --chrome-native-host` is a child of `/Applications/Google Chrome.app`. FDs show stdio pipes to Chrome and a unix socket. No TCP listeners in the entire claude process tree.

### Changes

- `README.md`: new section under "What cdc does NOT guarantee" explaining the limitation + workaround; troubleshooting entry; removed `--chrome` from usage examples throughout.
- `bin/cdc`: `warn_if_chrome_requested()` function emits a one-line warning to stderr when `--chrome` appears in pass-through args (suppressed in `--cdc-no-sandbox` mode since the user is already opting out of the sandbox).

## Test plan

- [x] `shellcheck bin/cdc && shfmt -d bin/cdc && bash -n bin/cdc` — lint-clean
- [x] `bats tests/` — all 5 pass
- [ ] Manual: `cdc --chrome` shows warning to stderr
- [ ] Manual: `cdc --cdc-no-sandbox --chrome` does NOT show warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)