### PR TITLE
refactor: use sbx exec -e for env passthrough; add TZ (closes #40)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,10 +128,12 @@ Key sbx facts that govern the implementation:
   It does NOT symlink `/home/agent/workspace` to the mount. `cdc` sets the
   initial working directory with `sbx exec -w` to land the agent at the
   real host path.
-- **sbx has no env var flag:** `sbx create` only supports `--branch`,
-  `--memory`, `--name`, `--template`. Config that requires shell environment
-  (TERM, LANG, etc.) must be passed via `env VAR=... claude` in the `sbx exec`
-  invocation.
+- **sbx exec accepts `-e KEY=VAL` for env passthrough.** Use this flag
+  (repeatable) for shell environment config that the sandbox needs but
+  that sbx doesn't inherit from the host (TERM, COLORTERM, LANG, LC_ALL,
+  TZ). cdc uses this so claude inside the sandbox gets colors, correct
+  locale, and matching timestamps. Note `sbx create` still has no env
+  flag — only `--branch`, `--memory`, `--name`, `--template`.
 - **Bypass mode via CLI flag:** sbx's claude image has
   `"defaultMode": "bypassPermissions"` in its baked-in `settings.json`, but
   Claude Code ignores that setting in environments it considers "Remote"

--- a/bin/cdc
+++ b/bin/cdc
@@ -555,19 +555,26 @@ build_sbx_argv() {
 	# so we cd there explicitly. Without this, claude starts in an empty dir
 	# and cannot see any project files.
 	#
-	# Wrap the claude invocation in `env VAR=... claude ...` to propagate
-	# terminal/color variables into the sandbox. sbx exec does not inherit
-	# the host's TERM/COLORTERM/etc, so without this claude defaults to
-	# minimal/no-color output.
+	# Pass terminal/locale env vars via `sbx exec -e KEY=VAL` (native
+	# passthrough) so claude inside the sandbox gets colors and proper
+	# locale. sbx exec does not inherit these from the host shell.
+	#
+	# TZ is derived so timestamps match the host clock: prefer $TZ if set,
+	# else parse /etc/localtime's symlink target. On macOS, /etc/localtime
+	# → /var/db/timezone/zoneinfo/<zone>. If neither is available, skip the
+	# flag — sandbox defaults to UTC.
+	local tz="${TZ:-}"
+	[[ -z "$tz" ]] && tz="$(readlink /etc/localtime 2>/dev/null | sed 's|.*/zoneinfo/||')"
+
 	CDC_SBX_ARGV=(
-		sbx exec "$exec_flags" -w "$pwd_abs" "$name"
-		env
-		"TERM=${TERM:-xterm-256color}"
-		"COLORTERM=${COLORTERM:-truecolor}"
-		"LANG=${LANG:-en_US.UTF-8}"
-		"LC_ALL=${LC_ALL:-en_US.UTF-8}"
-		claude
+		sbx exec "$exec_flags" -w "$pwd_abs"
+		-e "TERM=${TERM:-xterm-256color}"
+		-e "COLORTERM=${COLORTERM:-truecolor}"
+		-e "LANG=${LANG:-en_US.UTF-8}"
+		-e "LC_ALL=${LC_ALL:-en_US.UTF-8}"
 	)
+	[[ -n "$tz" ]] && CDC_SBX_ARGV+=(-e "TZ=$tz")
+	CDC_SBX_ARGV+=("$name" claude)
 
 	# Always pass --dangerously-skip-permissions unless --cdc-safe-mode is set.
 	# We cannot rely on sbx's baked-in settings.json having defaultMode:

--- a/tests/unit-build-sbx-argv.bats
+++ b/tests/unit-build-sbx-argv.bats
@@ -1,0 +1,116 @@
+#!/usr/bin/env bats
+load helpers/setup
+
+setup() {
+	cdc_setup
+	cdc_source
+	# build_sbx_argv needs these globals populated in cdc's normal flow.
+	# Provide the minimum subset needed by the function under test.
+	export CDC_SAFE_MODE=0
+	CLAUDE_ARGS=()
+	# Give compute_sandbox_name a cwd it can hash deterministically.
+	cd "$CDC_TEST_DIR"
+}
+teardown() { cdc_teardown; }
+
+# Helper — return the index of the first matching element in CDC_SBX_ARGV.
+_argv_index_of() {
+	local needle="$1"
+	local i
+	for i in "${!CDC_SBX_ARGV[@]}"; do
+		if [[ "${CDC_SBX_ARGV[i]}" == "$needle" ]]; then
+			printf '%s\n' "$i"
+			return 0
+		fi
+	done
+	return 1
+}
+
+@test "CDC_SBX_ARGV contains -e TERM=..." {
+	build_sbx_argv
+	local found=0 j
+	for j in "${!CDC_SBX_ARGV[@]}"; do
+		if [[ "${CDC_SBX_ARGV[j]}" == "-e" && "${CDC_SBX_ARGV[j+1]}" == TERM=* ]]; then
+			found=1
+			break
+		fi
+	done
+	[ "$found" -eq 1 ]
+}
+
+@test "CDC_SBX_ARGV contains -e COLORTERM=..." {
+	build_sbx_argv
+	local found=0 j
+	for j in "${!CDC_SBX_ARGV[@]}"; do
+		if [[ "${CDC_SBX_ARGV[j]}" == "-e" && "${CDC_SBX_ARGV[j+1]}" == COLORTERM=* ]]; then
+			found=1
+			break
+		fi
+	done
+	[ "$found" -eq 1 ]
+}
+
+@test "CDC_SBX_ARGV contains -e LANG=... and -e LC_ALL=..." {
+	build_sbx_argv
+	local lang_found=0 lcall_found=0 j
+	for j in "${!CDC_SBX_ARGV[@]}"; do
+		if [[ "${CDC_SBX_ARGV[j]}" == "-e" ]]; then
+			[[ "${CDC_SBX_ARGV[j+1]}" == LANG=* ]] && lang_found=1
+			[[ "${CDC_SBX_ARGV[j+1]}" == LC_ALL=* ]] && lcall_found=1
+		fi
+	done
+	[ "$lang_found" -eq 1 ]
+	[ "$lcall_found" -eq 1 ]
+}
+
+@test "CDC_SBX_ARGV contains -e TZ=<value> when TZ is exported" {
+	export TZ="America/Denver"
+	build_sbx_argv
+	local found=0 j
+	for j in "${!CDC_SBX_ARGV[@]}"; do
+		if [[ "${CDC_SBX_ARGV[j]}" == "-e" && "${CDC_SBX_ARGV[j+1]}" == "TZ=America/Denver" ]]; then
+			found=1
+			break
+		fi
+	done
+	[ "$found" -eq 1 ]
+}
+
+@test "all -e flags appear before the sandbox name" {
+	build_sbx_argv
+	local name
+	name="$(compute_sandbox_name)"
+	local name_idx last_e_idx=-1 j
+	name_idx=$(_argv_index_of "$name")
+	[ -n "$name_idx" ]
+	for j in "${!CDC_SBX_ARGV[@]}"; do
+		if [[ "${CDC_SBX_ARGV[j]}" == "-e" ]]; then
+			last_e_idx=$j
+		fi
+	done
+	[ "$last_e_idx" -lt "$name_idx" ]
+}
+
+@test "claude appears after the sandbox name" {
+	build_sbx_argv
+	local name
+	name="$(compute_sandbox_name)"
+	local name_idx claude_idx
+	name_idx=$(_argv_index_of "$name")
+	claude_idx=$(_argv_index_of "claude")
+	[ -n "$name_idx" ]
+	[ -n "$claude_idx" ]
+	[ "$claude_idx" -gt "$name_idx" ]
+}
+
+@test "CDC_SBX_ARGV no longer contains the bare env wrapper" {
+	build_sbx_argv
+	local j has_env=0
+	for j in "${!CDC_SBX_ARGV[@]}"; do
+		if [[ "${CDC_SBX_ARGV[j]}" == "env" ]]; then
+			has_env=1
+			break
+		fi
+	done
+	[ "$has_env" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

Closes #40.

- Replace the in-sandbox `env KEY=VAL ... claude` wrapper with native `sbx exec -e KEY=VAL` flags for `TERM`, `COLORTERM`, `LANG`, `LC_ALL`. No behavior change — same defaults, same values.
- Also forward `TZ` so timestamps inside the sandbox match the host clock. Derivation: `$TZ` if set, else parse `/etc/localtime`'s symlink target. Silent fallback to UTC if neither resolves.
- 7 new bats assertions in `tests/unit-build-sbx-argv.bats` lock the new argv shape.
- `CLAUDE.md` "Key sbx facts" bullet updated — the old "sbx has no env var flag" text was factually wrong.

### Before

```
sbx exec -it -w <pwd> <name> env TERM=... COLORTERM=... LANG=... LC_ALL=... claude --dangerously-skip-permissions
```

### After

```
sbx exec -it -w <pwd> -e TERM=... -e COLORTERM=... -e LANG=... -e LC_ALL=... -e TZ=America/Boise <name> claude --dangerously-skip-permissions
```

- Env vars appear in sbx's own argv (visible in dry-run + sbx debug output).
- One fewer layer of indirection — no in-sandbox `env` binary in the chain.
- Matches sbx-native idioms from `sbx exec --help`.

## Test plan

- [x] 7 new bats assertions in `tests/unit-build-sbx-argv.bats`:
  - `-e TERM=...`, `-e COLORTERM=...`, `-e LANG=...`, `-e LC_ALL=...` entries present
  - `-e TZ=...` present when \`TZ\` is exported
  - all `-e` flags appear before the sandbox name
  - `claude` appears after the sandbox name
  - no bare `env` entry in the argv
- [x] \`shellcheck bin/cdc && shfmt -d bin/cdc && bash -n bin/cdc\` — clean
- [x] \`bats tests/\` — 12 tests pass (5 pre-existing + 7 new)
- [x] \`./bin/cdc --cdc-dry-run\` — printed argv shows new shape with resolved TZ
- [x] Manual end-to-end — claude in sandbox shows colors and host-matching timezone

🤖 Generated with [Claude Code](https://claude.com/claude-code)