### PR TITLE
feat: add --cdc-publish for sbx port forwarding (closes #39)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Run Claude Code in dangerous mode safely inside a fast, easy-to-use microVM that
 - [Install](#install)
 - [Updating](#updating)
 - [GitHub access from the sandbox](#github-access-from-the-sandbox)
+- [Viewing a sandbox-hosted service](#viewing-a-sandbox-hosted-service)
 - [Quick start](#quick-start)
 - [How it works](#how-it-works)
 - [Configuration](#configuration)
@@ -509,6 +510,72 @@ running (delete repos, push malicious code, etc.). Scope your token or
 switch to fine-grained GitHub tokens if that's a concern. See
 [Recommended: credential scoping](#recommended-credential-scoping).
 
+## Viewing a sandbox-hosted service
+
+When claude starts a dev server (Next.js, Vite, `python -m http.server`, etc.)
+inside the sandbox, your host browser can't reach it out of the box — the
+sandbox has its own network namespace, so `http://localhost:3000` on the host
+and `http://localhost:3000` inside the sandbox are different things.
+
+### Quick path — `--cdc-publish`
+
+```bash
+cdc --cdc-publish 3000
+```
+
+Start your dev server inside the sandbox as usual. cdc publishes the port
+via sbx before attaching, then prints the resolved binding to stderr:
+
+```
+cdc: published http://127.0.0.1:3000 -> sandbox:3000 (tcp)
+```
+
+**Make sure the server inside the sandbox binds `0.0.0.0`, not
+`127.0.0.1`.** sbx port publishing crosses the VM boundary; a loopback-only
+listener inside the VM isn't reachable. Common flags:
+
+- Next.js: `next dev -H 0.0.0.0`
+- Vite: `vite --host 0.0.0.0`
+- Python: `python -m http.server 3000 --bind 0.0.0.0`
+
+### Spec syntax
+
+`--cdc-publish` accepts the same grammar as `sbx ports --publish`:
+
+```bash
+cdc --cdc-publish 3000                       # ephemeral host port -> sandbox:3000/tcp
+cdc --cdc-publish 8080:80                    # host:8080 -> sandbox:80
+cdc --cdc-publish 127.0.0.1:3000:3000        # explicit host bind
+cdc --cdc-publish 5353/udp                   # protocol override
+```
+
+The flag is repeatable:
+
+```bash
+cdc --cdc-publish 3000 --cdc-publish 8080
+```
+
+### Lifecycle
+
+- Ports are published for the duration of the session. cdc runs
+  `sbx ports --unpublish` for every spec it published before it stops the
+  sandbox on exit (Ctrl-C included).
+- `--cdc-keep-running` keeps the sandbox AND the ports alive.
+- `--cdc-dry-run` prints what would be published without doing it.
+
+### Manual escape hatch
+
+If you'd rather manage ports by hand on a sandbox you already have:
+
+```bash
+cdc --cdc-ls                          # find the sandbox name
+sbx ports <sandbox-name> --publish 3000
+sbx ports <sandbox-name>              # list current bindings
+sbx ports <sandbox-name> --unpublish 3000
+```
+
+Full syntax: `sbx ports --help`.
+
 ## Quick start
 
 ```bash
@@ -683,6 +750,7 @@ through to `claude` untouched.
 | `--cdc-name <label>`       | Named sandbox (for running parallel sessions in the same dir)  |
 | `--cdc-mount <path>[:ro]`  | Add an extra mount for this invocation (repeatable)            |
 | `--cdc-no-mount <path>`    | Skip a config-file mount for this invocation (repeatable)      |
+| `--cdc-publish <spec>`     | Publish a sandbox port to the host (repeatable; uses `sbx ports` syntax) |
 | `--cdc-no-sandbox`         | Escape hatch -- exec host `claude` directly                     |
 | `--cdc-rm [name]`          | Remove the sandbox for cwd (or the named one), with a prompt   |
 | `--cdc-ls`                 | List active sandboxes                                          |
@@ -713,6 +781,9 @@ cdc --cdc-mount ~/Projects/weird-experiment:ro -c
 
 # One-off: don't let the sandbox see ~/Downloads this session
 cdc --cdc-no-mount ~/Downloads
+
+# Expose a dev server running inside the sandbox
+cdc --cdc-publish 3000
 
 # Skip AWS credentials for a session that doesn't need them
 cdc --cdc-no-mount ~/.aws -c

--- a/bin/cdc
+++ b/bin/cdc
@@ -798,6 +798,9 @@ dry_run_output() {
 
 main() {
 	parse_args "$@"
+	if [[ $CDC_NO_SANDBOX -eq 1 && ${#CDC_PUBLISH_SPECS[@]} -gt 0 ]]; then
+		die "--cdc-publish cannot be combined with --cdc-no-sandbox (no sandbox to publish into)"
+	fi
 	if [[ $CDC_DOCTOR -eq 1 ]]; then
 		run_doctor
 		return $?

--- a/bin/cdc
+++ b/bin/cdc
@@ -221,6 +221,7 @@ WRAPPER FLAGS (consumed by cdc, not forwarded):
     --cdc-name <label>       Named sandbox for parallelism
     --cdc-mount <path>[:ro]  Add an extra mount for this invocation (repeatable)
     --cdc-no-mount <path>    Skip a config-file mount for this invocation (repeatable)
+    --cdc-publish <spec>     Publish sandbox port to host (repeatable; sbx ports syntax)
     --cdc-no-sandbox         Escape hatch — exec host claude directly
     --cdc-rm [name]          Remove the sandbox for cwd (or the named one)
     --cdc-ls                 List active sandboxes

--- a/bin/cdc
+++ b/bin/cdc
@@ -713,6 +713,23 @@ run_sandbox() {
 	# Step 2b: install sandbox-specific CLAUDE.md notes (idempotent)
 	install_sandbox_notes "$name"
 
+	# Step 2c: publish requested ports (after create+symlinks+notes, before attach)
+	if [[ ${#CDC_PUBLISH_SPECS[@]} -gt 0 ]]; then
+		publish_ports "$name" || {
+			local pub_rc=$?
+			echo "cdc: port publish failed; aborting before attach" >&2
+			# Partial-publish cleanup: unpublish_ports swallows errors, so
+			# it's safe even for specs that never published. Otherwise an
+			# earlier successful publish leaks into the next invocation.
+			unpublish_ports "$name"
+			spinner_stop
+			if [[ $CDC_KEEP_RUNNING -eq 0 ]]; then
+				sbx stop "$name" >/dev/null 2>&1 || true
+			fi
+			return "$pub_rc"
+		}
+	fi
+
 	# sbx race workaround: sleep before the interactive attach to let the
 	# daemon settle — see CLAUDE.md Lesson 5.
 	sleep 1

--- a/bin/cdc
+++ b/bin/cdc
@@ -580,6 +580,8 @@ def sandbox_port(spec):
 wanted = {sandbox_port(s) for s in specs if sandbox_port(s) is not None}
 try:
     data = json.loads(raw)
+    if not isinstance(data, list):
+        sys.exit(1)
 except Exception:
     sys.exit(1)
 for entry in data:
@@ -588,6 +590,8 @@ for entry in data:
         continue
     host_ip = entry.get("host_ip", "127.0.0.1")
     host_port = entry.get("host_port")
+    if host_port is None:
+        continue
     proto = entry.get("protocol", "tcp")
     print(f"cdc: published http://{host_ip}:{host_port} -> sandbox:{sp} ({proto})")
 PY

--- a/bin/cdc
+++ b/bin/cdc
@@ -534,6 +534,68 @@ Use any of these instead — all return full data:
 NOTES
 }
 
+publish_ports() {
+	# Publish each --cdc-publish spec via `sbx ports <name> --publish <spec>`.
+	# Returns the exit code of the first failing spec (0 if all succeed).
+	# Callers should run unpublish_ports on failure to avoid leaking a
+	# partial-publish into the next cdc invocation.
+	local name="$1" spec rc
+	for spec in "${CDC_PUBLISH_SPECS[@]+"${CDC_PUBLISH_SPECS[@]}"}"; do
+		sbx ports "$name" --publish "$spec" || {
+			rc=$?
+			return "$rc"
+		}
+	done
+	print_resolved_bindings "$name"
+}
+
+print_resolved_bindings() {
+	# Best-effort: list bindings from `sbx ports <name> --json` and print
+	# one human-readable line per spec we asked for. If python3 is missing
+	# or the JSON parse fails, fall back to a generic note.
+	local name="$1" json
+	json="$(sbx ports "$name" --json 2>/dev/null || true)"
+	if [[ -z "$json" ]]; then
+		return 0
+	fi
+	if command -v python3 >/dev/null 2>&1; then
+		CDC_PUBLISH_SPECS_JOINED="$(
+			IFS=,
+			printf '%s' "${CDC_PUBLISH_SPECS[*]:-}"
+		)" \
+			python3 - "$json" <<'PY' >&2 || \
+			echo "cdc: (could not parse 'sbx ports --json' output; run 'sbx ports $name' to see bindings)" >&2
+import json, os, sys
+raw = sys.argv[1]
+specs = [s for s in os.environ.get("CDC_PUBLISH_SPECS_JOINED", "").split(",") if s]
+
+def sandbox_port(spec):
+    base = spec.split("/", 1)[0]
+    parts = base.split(":")
+    try:
+        return int(parts[-1])
+    except ValueError:
+        return None
+
+wanted = {sandbox_port(s) for s in specs if sandbox_port(s) is not None}
+try:
+    data = json.loads(raw)
+except Exception:
+    sys.exit(1)
+for entry in data:
+    sp = entry.get("sandbox_port")
+    if sp not in wanted:
+        continue
+    host_ip = entry.get("host_ip", "127.0.0.1")
+    host_port = entry.get("host_port")
+    proto = entry.get("protocol", "tcp")
+    print(f"cdc: published http://{host_ip}:{host_port} -> sandbox:{sp} ({proto})")
+PY
+	else
+		echo "cdc: (python3 not found; run 'sbx ports $name' to see bindings)" >&2
+	fi
+}
+
 build_sbx_argv() {
 	# Show the attach form that actually runs. We use `sbx exec` instead of
 	# `sbx run` because sbx's agent launcher misbehaves with our credential

--- a/bin/cdc
+++ b/bin/cdc
@@ -600,6 +600,17 @@ PY
 	fi
 }
 
+unpublish_ports() {
+	# Best-effort cleanup. Never fails — unpublish errors are logged as
+	# warnings so they cannot mask claude's real exit code.
+	local name="$1" spec err
+	for spec in "${CDC_PUBLISH_SPECS[@]+"${CDC_PUBLISH_SPECS[@]}"}"; do
+		err="$(sbx ports "$name" --unpublish "$spec" 2>&1)" || \
+			echo "cdc: warn: could not unpublish $spec: $err" >&2
+	done
+	return 0
+}
+
 build_sbx_argv() {
 	# Show the attach form that actually runs. We use `sbx exec` instead of
 	# `sbx run` because sbx's agent launcher misbehaves with our credential

--- a/bin/cdc
+++ b/bin/cdc
@@ -256,6 +256,7 @@ CDC_RM_NAME=""
 CDC_KEEP_RUNNING=0
 CDC_SAFE_MODE=0
 CDC_EXTRA_MOUNTS=()
+CDC_PUBLISH_SPECS=()
 CDC_SKIP_MOUNTS=()
 CDC_CONFIG_MOUNTS=()
 CDC_RESOLVED_MOUNTS=()
@@ -697,6 +698,11 @@ parse_args() {
 		--cdc-no-mount)
 			[[ $# -ge 2 ]] || die "--cdc-no-mount requires a path"
 			CDC_SKIP_MOUNTS+=("$2")
+			shift 2
+			;;
+		--cdc-publish)
+			[[ $# -ge 2 ]] || die "--cdc-publish requires a <spec> value"
+			CDC_PUBLISH_SPECS+=("$2")
 			shift 2
 			;;
 		--cdc-no-sandbox)

--- a/bin/cdc
+++ b/bin/cdc
@@ -884,6 +884,15 @@ dry_run_output() {
 		done
 	fi
 	echo
+	if [[ ${#CDC_PUBLISH_SPECS[@]} -gt 0 ]]; then
+		echo "PUBLISH (would run after create):"
+		local spec sandbox_name
+		sandbox_name="$(compute_sandbox_name)"
+		for spec in "${CDC_PUBLISH_SPECS[@]}"; do
+			echo "  sbx ports $sandbox_name --publish $spec"
+		done
+		echo
+	fi
 	echo "CLAUDE_ARGS: ${CLAUDE_ARGS[*]:-<none>}"
 	echo
 	echo "COMMAND:"

--- a/bin/cdc
+++ b/bin/cdc
@@ -258,6 +258,7 @@ CDC_KEEP_RUNNING=0
 CDC_SAFE_MODE=0
 CDC_EXTRA_MOUNTS=()
 CDC_PUBLISH_SPECS=()
+CDC_PUBLISH_RESOLVED_SPECS=()
 CDC_SKIP_MOUNTS=()
 CDC_CONFIG_MOUNTS=()
 CDC_RESOLVED_MOUNTS=()
@@ -538,14 +539,27 @@ NOTES
 publish_ports() {
 	# Publish each --cdc-publish spec via `sbx ports <name> --publish <spec>`.
 	# Returns the exit code of the first failing spec (0 if all succeed).
-	# Callers should run unpublish_ports on failure to avoid leaking a
-	# partial-publish into the next cdc invocation.
-	local name="$1" spec rc
+	# Captures sbx's "Published HOST_IP:HOST_PORT -> SANDBOX_PORT/PROTO" output
+	# into CDC_PUBLISH_RESOLVED_SPECS so unpublish has the host_port that sbx
+	# allocated for ephemeral specs (bare SANDBOX_PORT requires the full
+	# HOST_IP:HOST_PORT:SANDBOX_PORT form to unpublish).
+	local name="$1" spec rc out resolved
+	CDC_PUBLISH_RESOLVED_SPECS=()
 	for spec in "${CDC_PUBLISH_SPECS[@]+"${CDC_PUBLISH_SPECS[@]}"}"; do
-		sbx ports "$name" --publish "$spec" || {
+		out="$(sbx ports "$name" --publish "$spec" 2>&1)" || {
 			rc=$?
+			printf '%s\n' "$out" >&2
 			return "$rc"
 		}
+		# Echo sbx's published line so the user still sees it (we captured stdout)
+		printf '%s\n' "$out" >&2
+		# Parse "Published HOST_IP:HOST_PORT -> SANDBOX_PORT/PROTO"
+		resolved="$(printf '%s' "$out" | sed -n 's/^Published \(.*\) -> \(.*\)$/\1:\2/p' | head -n1)"
+		if [[ -n "$resolved" ]]; then
+			CDC_PUBLISH_RESOLVED_SPECS+=("$resolved")
+		else
+			CDC_PUBLISH_RESOLVED_SPECS+=("$spec")
+		fi
 	done
 	print_resolved_bindings "$name"
 }
@@ -604,8 +618,11 @@ PY
 unpublish_ports() {
 	# Best-effort cleanup. Never fails — unpublish errors are logged as
 	# warnings so they cannot mask claude's real exit code.
+	# Iterates CDC_PUBLISH_RESOLVED_SPECS (the canonicalized form captured by
+	# publish_ports) so unpublish works for ephemeral specs that omitted the
+	# host port.
 	local name="$1" spec err
-	for spec in "${CDC_PUBLISH_SPECS[@]+"${CDC_PUBLISH_SPECS[@]}"}"; do
+	for spec in "${CDC_PUBLISH_RESOLVED_SPECS[@]+"${CDC_PUBLISH_RESOLVED_SPECS[@]}"}"; do
 		err="$(sbx ports "$name" --unpublish "$spec" 2>&1)" ||
 			echo "cdc: warn: could not unpublish $spec: $err" >&2
 	done

--- a/bin/cdc
+++ b/bin/cdc
@@ -554,10 +554,15 @@ publish_ports() {
 		# Echo sbx's published line so the user still sees it (we captured stdout)
 		printf '%s\n' "$out" >&2
 		# Parse "Published HOST_IP:HOST_PORT -> SANDBOX_PORT/PROTO"
-		resolved="$(printf '%s' "$out" | sed -n 's/^Published \(.*\) -> \(.*\)$/\1:\2/p' | head -n1)"
+		resolved="$(printf '%s' "$out" | sed -n 's/^Published \(.*\) -> \(.*\)$/\1:\2/p')"
 		if [[ -n "$resolved" ]]; then
-			CDC_PUBLISH_RESOLVED_SPECS+=("$resolved")
+			# resolved may be multi-line if sbx ever emits multiple
+			# Published lines per call (e.g. dual-stack). Append each.
+			while IFS= read -r line; do
+				CDC_PUBLISH_RESOLVED_SPECS+=("$line")
+			done <<<"$resolved"
 		else
+			echo "cdc: warn: could not parse sbx publish output for $spec; unpublish may fail at session end" >&2
 			CDC_PUBLISH_RESOLVED_SPECS+=("$spec")
 		fi
 	done

--- a/bin/cdc
+++ b/bin/cdc
@@ -559,12 +559,10 @@ print_resolved_bindings() {
 		return 0
 	fi
 	if command -v python3 >/dev/null 2>&1; then
-		CDC_PUBLISH_SPECS_JOINED="$(
+		if ! CDC_PUBLISH_SPECS_JOINED="$(
 			IFS=,
 			printf '%s' "${CDC_PUBLISH_SPECS[*]:-}"
-		)" \
-			python3 - "$json" <<'PY' >&2 || \
-			echo "cdc: (could not parse 'sbx ports --json' output; run 'sbx ports $name' to see bindings)" >&2
+		)" python3 - "$json" <<'PY' >&2; then
 import json, os, sys
 raw = sys.argv[1]
 specs = [s for s in os.environ.get("CDC_PUBLISH_SPECS_JOINED", "").split(",") if s]
@@ -595,6 +593,8 @@ for entry in data:
     proto = entry.get("protocol", "tcp")
     print(f"cdc: published http://{host_ip}:{host_port} -> sandbox:{sp} ({proto})")
 PY
+			echo "cdc: (could not parse 'sbx ports --json' output; run 'sbx ports $name' to see bindings)" >&2
+		fi
 	else
 		echo "cdc: (python3 not found; run 'sbx ports $name' to see bindings)" >&2
 	fi
@@ -605,7 +605,7 @@ unpublish_ports() {
 	# warnings so they cannot mask claude's real exit code.
 	local name="$1" spec err
 	for spec in "${CDC_PUBLISH_SPECS[@]+"${CDC_PUBLISH_SPECS[@]}"}"; do
-		err="$(sbx ports "$name" --unpublish "$spec" 2>&1)" || \
+		err="$(sbx ports "$name" --unpublish "$spec" 2>&1)" ||
 			echo "cdc: warn: could not unpublish $spec: $err" >&2
 	done
 	return 0

--- a/bin/cdc
+++ b/bin/cdc
@@ -744,7 +744,7 @@ run_sandbox() {
 
 	# Register cleanup trap so sandbox stops even on Ctrl-C / SIGTERM
 	if [[ $CDC_KEEP_RUNNING -eq 0 ]]; then
-		trap 'sbx stop "$name" >/dev/null 2>&1 || true; exit 130' INT TERM
+		trap 'unpublish_ports "$name"; sbx stop "$name" >/dev/null 2>&1 || true; exit 130' INT TERM
 	fi
 
 	local attempt
@@ -766,6 +766,7 @@ run_sandbox() {
 
 	# Auto-stop the sandbox to free resources (unless --cdc-keep-running)
 	if [[ $CDC_KEEP_RUNNING -eq 0 ]]; then
+		unpublish_ports "$name"
 		sbx stop "$name" >/dev/null 2>&1 || true
 	fi
 

--- a/tests/helpers/mock-sbx
+++ b/tests/helpers/mock-sbx
@@ -2,6 +2,38 @@
 : "${CDC_TEST_LOG:=/tmp/cdc-test-log}"
 { printf 'sbx'; for a in "$@"; do printf ' %q' "$a"; done; printf '\n'; } >>"$CDC_TEST_LOG"
 case "$1" in
-ls | create | stop | rm) exit 0 ;;
+ls | create | stop | rm)
+	exit 0
+	;;
+exec)
+	# Tests can opt into a canned exit code via CDC_MOCK_EXEC_EXIT.
+	exit "${CDC_MOCK_EXEC_EXIT:-0}"
+	;;
+ports)
+	# Tests can force a publish failure via CDC_MOCK_PUBLISH_EXIT.
+	# --json emits CDC_MOCK_PORTS_JSON (default: []).
+	local_has_json=0
+	for arg in "$@"; do
+		if [[ "$arg" == "--json" ]]; then local_has_json=1; fi
+	done
+	if [[ $local_has_json -eq 1 ]]; then
+		printf '%s\n' "${CDC_MOCK_PORTS_JSON:-[]}"
+		exit 0
+	fi
+	for arg in "$@"; do
+		if [[ "$arg" == "--publish" ]]; then
+			exit "${CDC_MOCK_PUBLISH_EXIT:-0}"
+		fi
+		if [[ "$arg" == "--unpublish" ]]; then
+			exit "${CDC_MOCK_UNPUBLISH_EXIT:-0}"
+		fi
+	done
+	exit 0
+	;;
+secret)
+	# sbx secret list -g / set -g github — used by ensure_github_secret
+	# and preflight_github_secret. Keep no-op for test environments.
+	exit 0
+	;;
 esac
 exit 1

--- a/tests/helpers/mock-sbx
+++ b/tests/helpers/mock-sbx
@@ -26,6 +26,18 @@ ports)
 		if [[ "$arg" == "--publish" ]]; then
 			i=$((i + 1))
 			spec="${!i:-}"
+			# Track publish call count via $CDC_TEST_DIR/.publish-count.
+			# Lets tests simulate "first call succeeds, Nth call fails" via
+			# CDC_MOCK_PUBLISH_FAIL_AT=N + CDC_MOCK_PUBLISH_EXIT=<code>.
+			count_file="${CDC_TEST_DIR:-/tmp}/.publish-count"
+			count="$(cat "$count_file" 2>/dev/null || echo 0)"
+			count=$((count + 1))
+			echo "$count" >"$count_file"
+			if [[ -n "${CDC_MOCK_PUBLISH_FAIL_AT:-}" && "$count" -eq "$CDC_MOCK_PUBLISH_FAIL_AT" ]]; then
+				# Print sbx-style error to stderr so publish_ports can echo it.
+				echo "ERROR: simulated publish failure on call $count" >&2
+				exit "${CDC_MOCK_PUBLISH_EXIT:-1}"
+			fi
 			# Parse spec into components. Supported forms:
 			#   SANDBOX_PORT                       → ephemeral host port (49153)
 			#   HOST_PORT:SANDBOX_PORT             → use HOST_PORT as host port
@@ -57,6 +69,13 @@ ports)
 				sandbox_port="${rest##*:}"
 			fi
 			printf 'Published %s:%s -> %s/%s\n' "$host_ip" "$host_port" "$sandbox_port" "$proto"
+			# In selective-fail mode (CDC_MOCK_PUBLISH_FAIL_AT set), successful
+			# calls always exit 0 — the counter block above already handles the
+			# specific failing call. Without CDC_MOCK_PUBLISH_FAIL_AT, use
+			# CDC_MOCK_PUBLISH_EXIT so all-fail tests continue to work.
+			if [[ -n "${CDC_MOCK_PUBLISH_FAIL_AT:-}" ]]; then
+				exit 0
+			fi
 			exit "${CDC_MOCK_PUBLISH_EXIT:-0}"
 		fi
 		if [[ "$arg" == "--unpublish" ]]; then

--- a/tests/helpers/mock-sbx
+++ b/tests/helpers/mock-sbx
@@ -20,13 +20,49 @@ ports)
 		printf '%s\n' "${CDC_MOCK_PORTS_JSON:-[]}"
 		exit 0
 	fi
-	for arg in "$@"; do
+	i=1
+	while [[ $i -le $# ]]; do
+		arg="${!i}"
 		if [[ "$arg" == "--publish" ]]; then
+			i=$((i + 1))
+			spec="${!i:-}"
+			# Parse spec into components. Supported forms:
+			#   SANDBOX_PORT                       → ephemeral host port (49153)
+			#   HOST_PORT:SANDBOX_PORT             → use HOST_PORT as host port
+			#   HOST_IP:HOST_PORT:SANDBOX_PORT     → use HOST_IP and HOST_PORT
+			# Append /PROTO if present on the sandbox port; default proto is tcp.
+			host_ip="127.0.0.1"
+			proto="tcp"
+			# Strip /PROTO suffix if present
+			if [[ "$spec" == */* ]]; then
+				proto="${spec##*/}"
+				spec="${spec%%/*}"
+			fi
+			# Count colons to determine which form
+			colon_count="${spec//[^:]}"
+			if [[ ${#colon_count} -eq 0 ]]; then
+				# Bare sandbox port — sbx picks an ephemeral host port.
+				# Use 49153 (start of macOS ephemeral range) as a stable test value.
+				host_port=49153
+				sandbox_port="$spec"
+			elif [[ ${#colon_count} -eq 1 ]]; then
+				# HOST_PORT:SANDBOX_PORT
+				host_port="${spec%%:*}"
+				sandbox_port="${spec##*:}"
+			else
+				# HOST_IP:HOST_PORT:SANDBOX_PORT
+				host_ip="${spec%%:*}"
+				rest="${spec#*:}"
+				host_port="${rest%%:*}"
+				sandbox_port="${rest##*:}"
+			fi
+			printf 'Published %s:%s -> %s/%s\n' "$host_ip" "$host_port" "$sandbox_port" "$proto"
 			exit "${CDC_MOCK_PUBLISH_EXIT:-0}"
 		fi
 		if [[ "$arg" == "--unpublish" ]]; then
 			exit "${CDC_MOCK_UNPUBLISH_EXIT:-0}"
 		fi
+		i=$((i + 1))
 	done
 	exit 0
 	;;

--- a/tests/integration-run-sandbox.bats
+++ b/tests/integration-run-sandbox.bats
@@ -15,3 +15,42 @@ teardown() { cdc_teardown; }
 	repo_root="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
 	! grep -n 'inject_credentials' "$repo_root/bin/cdc"
 }
+
+@test "run_sandbox publishes ports before attach when --cdc-publish given" {
+	cdc_source
+	CDC_PUBLISH_SPECS=(3000)
+	CDC_KEEP_RUNNING=0
+	CDC_SAFE_MODE=0
+	CLAUDE_ARGS=()
+	export CDC_MOCK_PORTS_JSON='[]'
+	sandbox_exists() { return 0; }
+
+	run run_sandbox
+	[ "$status" -eq 0 ]
+	local publish_line exec_line
+	publish_line="$(grep -n -- '--publish 3000' "$CDC_TEST_LOG" | head -1 | cut -d: -f1)"
+	# The attach exec is the sbx exec that includes -w (working-dir flag);
+	# the earlier symlink and notes execs do not use -w.
+	exec_line="$(grep -n -- 'sbx exec.*-w' "$CDC_TEST_LOG" | head -1 | cut -d: -f1)"
+	[ -n "$publish_line" ]
+	[ -n "$exec_line" ]
+	[ "$publish_line" -lt "$exec_line" ]
+}
+
+@test "publish failure aborts before attach and runs unpublish cleanup" {
+	cdc_source
+	CDC_PUBLISH_SPECS=(3000 8080:80)
+	CDC_KEEP_RUNNING=0
+	CDC_SAFE_MODE=0
+	CLAUDE_ARGS=()
+	export CDC_MOCK_PORTS_JSON='[]'
+	export CDC_MOCK_PUBLISH_EXIT=2
+	sandbox_exists() { return 0; }
+
+	run run_sandbox
+	[ "$status" -ne 0 ]
+	# The attach exec includes -w; symlink/notes execs do not. Confirm no attach happened.
+	! grep -q -- 'sbx exec.*-w' "$CDC_TEST_LOG"
+	grep -q -- '--unpublish 3000' "$CDC_TEST_LOG"
+	grep -q -- '--unpublish 8080:80' "$CDC_TEST_LOG"
+}

--- a/tests/integration-run-sandbox.bats
+++ b/tests/integration-run-sandbox.bats
@@ -80,6 +80,28 @@ teardown() { cdc_teardown; }
 	[ "$unpub_line" -lt "$stop_line" ]
 }
 
+@test "partial publish failure unpublishes already-resolved specs" {
+	cdc_source
+	CDC_PUBLISH_SPECS=(3000 8080:80)
+	CDC_KEEP_RUNNING=0
+	CDC_SAFE_MODE=0
+	CLAUDE_ARGS=()
+	export CDC_MOCK_PORTS_JSON='[]'
+	export CDC_MOCK_PUBLISH_FAIL_AT=2
+	export CDC_MOCK_PUBLISH_EXIT=2
+	sandbox_exists() { return 0; }
+
+	run run_sandbox
+	[ "$status" -ne 0 ]
+	# Attach must NOT have happened
+	! grep -q 'sbx exec.*-w' "$CDC_TEST_LOG"
+	# First spec succeeded — its canonical form must have been unpublished.
+	# Mock allocates ephemeral host port 49153 for bare specs.
+	grep -q -- '--unpublish 127.0.0.1:49153:3000/tcp' "$CDC_TEST_LOG"
+	# Second spec failed before resolving — must NOT appear in unpublish.
+	! grep -q -- '--unpublish.*8080:80' "$CDC_TEST_LOG"
+}
+
 @test "--cdc-keep-running skips both unpublish and stop" {
 	cdc_source
 	CDC_PUBLISH_SPECS=(3000)

--- a/tests/integration-run-sandbox.bats
+++ b/tests/integration-run-sandbox.bats
@@ -39,6 +39,10 @@ teardown() { cdc_teardown; }
 
 @test "publish failure aborts before attach and runs unpublish cleanup" {
 	cdc_source
+	# Use a two-spec list but make only the second fail so the first gets resolved
+	# into CDC_PUBLISH_RESOLVED_SPECS and is cleaned up by unpublish_ports.
+	# We achieve this by pre-seeding CDC_PUBLISH_RESOLVED_SPECS with the first
+	# spec's canonical form to simulate a partial publish.
 	CDC_PUBLISH_SPECS=(3000 8080:80)
 	CDC_KEEP_RUNNING=0
 	CDC_SAFE_MODE=0
@@ -51,8 +55,10 @@ teardown() { cdc_teardown; }
 	[ "$status" -ne 0 ]
 	# The attach exec includes -w; symlink/notes execs do not. Confirm no attach happened.
 	! grep -q -- 'sbx exec.*-w' "$CDC_TEST_LOG"
-	grep -q -- '--unpublish 3000' "$CDC_TEST_LOG"
-	grep -q -- '--unpublish 8080:80' "$CDC_TEST_LOG"
+	# With CDC_MOCK_PUBLISH_EXIT=2 the very first spec fails so no specs are
+	# resolved; unpublish_ports is a no-op. Confirm at least one --publish was
+	# attempted (proving the abort path was reached through publish_ports).
+	grep -q -- '--publish.*3000' "$CDC_TEST_LOG"
 }
 
 @test "run_sandbox unpublishes ports after clean exit before sbx stop" {
@@ -67,7 +73,7 @@ teardown() { cdc_teardown; }
 	run run_sandbox
 	[ "$status" -eq 0 ]
 	local unpub_line stop_line
-	unpub_line="$(grep -n -- '--unpublish 3000' "$CDC_TEST_LOG" | head -1 | cut -d: -f1)"
+	unpub_line="$(grep -n -- '--unpublish.*3000' "$CDC_TEST_LOG" | head -1 | cut -d: -f1)"
 	stop_line="$(grep -n '^sbx stop' "$CDC_TEST_LOG" | head -1 | cut -d: -f1)"
 	[ -n "$unpub_line" ]
 	[ -n "$stop_line" ]

--- a/tests/integration-run-sandbox.bats
+++ b/tests/integration-run-sandbox.bats
@@ -54,3 +54,37 @@ teardown() { cdc_teardown; }
 	grep -q -- '--unpublish 3000' "$CDC_TEST_LOG"
 	grep -q -- '--unpublish 8080:80' "$CDC_TEST_LOG"
 }
+
+@test "run_sandbox unpublishes ports after clean exit before sbx stop" {
+	cdc_source
+	CDC_PUBLISH_SPECS=(3000)
+	CDC_KEEP_RUNNING=0
+	CDC_SAFE_MODE=0
+	CLAUDE_ARGS=()
+	export CDC_MOCK_PORTS_JSON='[]'
+	sandbox_exists() { return 0; }
+
+	run run_sandbox
+	[ "$status" -eq 0 ]
+	local unpub_line stop_line
+	unpub_line="$(grep -n -- '--unpublish 3000' "$CDC_TEST_LOG" | head -1 | cut -d: -f1)"
+	stop_line="$(grep -n '^sbx stop' "$CDC_TEST_LOG" | head -1 | cut -d: -f1)"
+	[ -n "$unpub_line" ]
+	[ -n "$stop_line" ]
+	[ "$unpub_line" -lt "$stop_line" ]
+}
+
+@test "--cdc-keep-running skips both unpublish and stop" {
+	cdc_source
+	CDC_PUBLISH_SPECS=(3000)
+	CDC_KEEP_RUNNING=1
+	CDC_SAFE_MODE=0
+	CLAUDE_ARGS=()
+	export CDC_MOCK_PORTS_JSON='[]'
+	sandbox_exists() { return 0; }
+
+	run run_sandbox
+	[ "$status" -eq 0 ]
+	! grep -q -- '--unpublish' "$CDC_TEST_LOG"
+	! grep -q '^sbx stop' "$CDC_TEST_LOG"
+}

--- a/tests/unit-publish-dry-run.bats
+++ b/tests/unit-publish-dry-run.bats
@@ -1,0 +1,36 @@
+#!/usr/bin/env bats
+load helpers/setup
+
+setup() {
+	cdc_setup
+}
+teardown() { cdc_teardown; }
+
+@test "dry-run with --cdc-publish shows PUBLISH block" {
+	local repo_root
+	repo_root="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
+	cd "$CDC_TEST_DIR"
+	run bash -c "'$repo_root/bin/cdc' --cdc-publish 3000 --cdc-publish 8080:80 --cdc-dry-run"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"PUBLISH (would run after create):"* ]]
+	[[ "$output" == *"--publish 3000"* ]]
+	[[ "$output" == *"--publish 8080:80"* ]]
+}
+
+@test "dry-run without --cdc-publish omits PUBLISH block" {
+	local repo_root
+	repo_root="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
+	cd "$CDC_TEST_DIR"
+	run bash -c "'$repo_root/bin/cdc' --cdc-dry-run"
+	[ "$status" -eq 0 ]
+	[[ "$output" != *"PUBLISH"* ]]
+}
+
+@test "dry-run with --cdc-publish does NOT invoke sbx ports" {
+	local repo_root
+	repo_root="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
+	cd "$CDC_TEST_DIR"
+	run bash -c "'$repo_root/bin/cdc' --cdc-publish 3000 --cdc-dry-run"
+	[ "$status" -eq 0 ]
+	! grep -q 'sbx ports' "$CDC_TEST_LOG"
+}

--- a/tests/unit-publish-parsing.bats
+++ b/tests/unit-publish-parsing.bats
@@ -37,3 +37,11 @@ teardown() { cdc_teardown; }
 	[ "${#CLAUDE_ARGS[@]}" -eq 1 ]
 	[ "${CLAUDE_ARGS[0]}" = "-c" ]
 }
+
+@test "--cdc-no-sandbox with --cdc-publish exits with a clear conflict message" {
+	local repo_root
+	repo_root="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
+	run bash -c "'$repo_root/bin/cdc' --cdc-no-sandbox --cdc-publish 3000 --cdc-dry-run"
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"--cdc-publish cannot be combined with --cdc-no-sandbox"* ]]
+}

--- a/tests/unit-publish-parsing.bats
+++ b/tests/unit-publish-parsing.bats
@@ -103,3 +103,30 @@ teardown() { cdc_teardown; }
 	[ "$status" -eq 0 ]
 	[[ "$output" == *"cdc: published http://127.0.0.1:54321 -> sandbox:3000 (tcp)"* ]]
 }
+
+@test "unpublish_ports runs sbx ports --unpublish for each spec" {
+	CDC_PUBLISH_SPECS=(3000 8080:80)
+	run unpublish_ports test-sandbox
+	[ "$status" -eq 0 ]
+	[[ "$(cdc_log_line 1)" == "sbx ports test-sandbox --unpublish 3000" ]]
+	[[ "$(cdc_log_line 2)" == "sbx ports test-sandbox --unpublish 8080:80" ]]
+}
+
+@test "unpublish_ports swallows errors and continues" {
+	CDC_PUBLISH_SPECS=(3000 8080:80)
+	export CDC_MOCK_UNPUBLISH_EXIT=1
+	run unpublish_ports test-sandbox
+	[ "$status" -eq 0 ]
+	[[ "$(cdc_log_line 1)" == *"--unpublish 3000"* ]]
+	[[ "$(cdc_log_line 2)" == *"--unpublish 8080:80"* ]]
+	[[ "$output" == *"cdc: warn: could not unpublish 3000"* ]]
+	[[ "$output" == *"cdc: warn: could not unpublish 8080:80"* ]]
+}
+
+@test "unpublish_ports is a no-op when CDC_PUBLISH_SPECS is empty" {
+	CDC_PUBLISH_SPECS=()
+	run unpublish_ports test-sandbox
+	[ "$status" -eq 0 ]
+	run wc -l <"$CDC_TEST_LOG"
+	[ "$output" -eq 0 ]
+}

--- a/tests/unit-publish-parsing.bats
+++ b/tests/unit-publish-parsing.bats
@@ -45,3 +45,24 @@ teardown() { cdc_teardown; }
 	[ "$status" -ne 0 ]
 	[[ "$output" == *"--cdc-publish cannot be combined with --cdc-no-sandbox"* ]]
 }
+
+@test "mock sbx accepts 'ports --publish' and logs argv" {
+	run sbx ports my-sandbox --publish 3000
+	[ "$status" -eq 0 ]
+	run cdc_log_line 1
+	[[ "$output" == "sbx ports my-sandbox --publish 3000" ]]
+}
+
+@test "mock sbx accepts 'ports --unpublish' and logs argv" {
+	run sbx ports my-sandbox --unpublish 3000
+	[ "$status" -eq 0 ]
+	run cdc_log_line 1
+	[[ "$output" == "sbx ports my-sandbox --unpublish 3000" ]]
+}
+
+@test "mock sbx 'ports --json' emits canned JSON on stdout" {
+	export CDC_MOCK_PORTS_JSON='[{"sandbox_port":3000,"host_ip":"127.0.0.1","host_port":54321,"protocol":"tcp"}]'
+	run sbx ports my-sandbox --json
+	[ "$status" -eq 0 ]
+	[[ "$output" == *'"sandbox_port":3000'* ]]
+}

--- a/tests/unit-publish-parsing.bats
+++ b/tests/unit-publish-parsing.bats
@@ -130,3 +130,11 @@ teardown() { cdc_teardown; }
 	run wc -l <"$CDC_TEST_LOG"
 	[ "$output" -eq 0 ]
 }
+
+@test "--cdc-help lists --cdc-publish" {
+	local repo_root
+	repo_root="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
+	run "$repo_root/bin/cdc" --cdc-help
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"--cdc-publish"* ]]
+}

--- a/tests/unit-publish-parsing.bats
+++ b/tests/unit-publish-parsing.bats
@@ -106,21 +106,28 @@ teardown() { cdc_teardown; }
 
 @test "unpublish_ports runs sbx ports --unpublish for each spec" {
 	CDC_PUBLISH_SPECS=(3000 8080:80)
+	export CDC_MOCK_PORTS_JSON='[]'
+	publish_ports test-sandbox >/dev/null 2>&1
 	run unpublish_ports test-sandbox
 	[ "$status" -eq 0 ]
-	[[ "$(cdc_log_line 1)" == "sbx ports test-sandbox --unpublish 3000" ]]
-	[[ "$(cdc_log_line 2)" == "sbx ports test-sandbox --unpublish 8080:80" ]]
+	# Log lines: 1=--publish 3000, 2=--publish 8080:80, 3=--json (print_resolved_bindings),
+	# 4=--unpublish canonical(3000), 5=--unpublish canonical(8080:80)
+	# Bare port 3000 → ephemeral 127.0.0.1:49153:3000/tcp; 8080:80 → 127.0.0.1:8080:80/tcp
+	[[ "$(cdc_log_line 4)" == "sbx ports test-sandbox --unpublish 127.0.0.1:49153:3000/tcp" ]]
+	[[ "$(cdc_log_line 5)" == "sbx ports test-sandbox --unpublish 127.0.0.1:8080:80/tcp" ]]
 }
 
 @test "unpublish_ports swallows errors and continues" {
 	CDC_PUBLISH_SPECS=(3000 8080:80)
+	export CDC_MOCK_PORTS_JSON='[]'
+	publish_ports test-sandbox >/dev/null 2>&1
 	export CDC_MOCK_UNPUBLISH_EXIT=1
 	run unpublish_ports test-sandbox
 	[ "$status" -eq 0 ]
-	[[ "$(cdc_log_line 1)" == *"--unpublish 3000"* ]]
-	[[ "$(cdc_log_line 2)" == *"--unpublish 8080:80"* ]]
-	[[ "$output" == *"cdc: warn: could not unpublish 3000"* ]]
-	[[ "$output" == *"cdc: warn: could not unpublish 8080:80"* ]]
+	[[ "$(cdc_log_line 4)" == *"--unpublish 127.0.0.1:49153:3000/tcp"* ]]
+	[[ "$(cdc_log_line 5)" == *"--unpublish 127.0.0.1:8080:80/tcp"* ]]
+	[[ "$output" == *"cdc: warn: could not unpublish 127.0.0.1:49153:3000/tcp"* ]]
+	[[ "$output" == *"cdc: warn: could not unpublish 127.0.0.1:8080:80/tcp"* ]]
 }
 
 @test "unpublish_ports is a no-op when CDC_PUBLISH_SPECS is empty" {

--- a/tests/unit-publish-parsing.bats
+++ b/tests/unit-publish-parsing.bats
@@ -66,3 +66,23 @@ teardown() { cdc_teardown; }
 	[ "$status" -eq 0 ]
 	[[ "$output" == *'"sandbox_port":3000'* ]]
 }
+
+@test "publish_ports runs sbx ports --publish for each spec in order" {
+	CDC_PUBLISH_SPECS=(3000 8080:80)
+	export CDC_MOCK_PORTS_JSON='[]'
+	run publish_ports test-sandbox
+	[ "$status" -eq 0 ]
+	local line1 line2
+	line1="$(cdc_log_line 1)"
+	line2="$(cdc_log_line 2)"
+	[[ "$line1" == "sbx ports test-sandbox --publish 3000" ]]
+	[[ "$line2" == "sbx ports test-sandbox --publish 8080:80" ]]
+}
+
+@test "publish_ports returns nonzero if sbx publish fails" {
+	CDC_PUBLISH_SPECS=(3000)
+	export CDC_MOCK_PUBLISH_EXIT=2
+	export CDC_MOCK_PORTS_JSON='[]'
+	run publish_ports test-sandbox
+	[ "$status" -eq 2 ]
+}

--- a/tests/unit-publish-parsing.bats
+++ b/tests/unit-publish-parsing.bats
@@ -86,3 +86,20 @@ teardown() { cdc_teardown; }
 	run publish_ports test-sandbox
 	[ "$status" -eq 2 ]
 }
+
+@test "print_resolved_bindings prints 'cdc: published' line to stderr" {
+	CDC_PUBLISH_SPECS=(3000)
+	export CDC_MOCK_PORTS_JSON='[{"sandbox_port":3000,"host_ip":"127.0.0.1","host_port":54321,"protocol":"tcp"}]'
+	run bash -c "
+		set -euo pipefail
+		export PATH='$PATH'
+		export CDC_MOCK_PORTS_JSON='$CDC_MOCK_PORTS_JSON'
+		export CDC_TEST_LOG='$CDC_TEST_LOG'
+		export HOME='$HOME'
+		source '$(cd "${BATS_TEST_DIRNAME}/.." && pwd)/bin/cdc'
+		CDC_PUBLISH_SPECS=(3000)
+		print_resolved_bindings test-sandbox 2>&1
+	"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"cdc: published http://127.0.0.1:54321 -> sandbox:3000 (tcp)"* ]]
+}

--- a/tests/unit-publish-parsing.bats
+++ b/tests/unit-publish-parsing.bats
@@ -1,0 +1,39 @@
+#!/usr/bin/env bats
+load helpers/setup
+
+setup() {
+	cdc_setup
+	cdc_source
+}
+teardown() { cdc_teardown; }
+
+@test "--cdc-publish populates CDC_PUBLISH_SPECS" {
+	CDC_PUBLISH_SPECS=()
+	CLAUDE_ARGS=()
+	parse_args --cdc-publish 3000
+	[ "${#CDC_PUBLISH_SPECS[@]}" -eq 1 ]
+	[ "${CDC_PUBLISH_SPECS[0]}" = "3000" ]
+}
+
+@test "repeated --cdc-publish accumulates in order" {
+	CDC_PUBLISH_SPECS=()
+	CLAUDE_ARGS=()
+	parse_args --cdc-publish 3000 --cdc-publish 8080:80
+	[ "${#CDC_PUBLISH_SPECS[@]}" -eq 2 ]
+	[ "${CDC_PUBLISH_SPECS[0]}" = "3000" ]
+	[ "${CDC_PUBLISH_SPECS[1]}" = "8080:80" ]
+}
+
+@test "--cdc-publish without a value exits nonzero with a clear message" {
+	run bash -c "source '$(cd "${BATS_TEST_DIRNAME}/.." && pwd)/bin/cdc'; parse_args --cdc-publish"
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"--cdc-publish requires a <spec> value"* ]]
+}
+
+@test "--cdc-publish value is not forwarded to CLAUDE_ARGS" {
+	CDC_PUBLISH_SPECS=()
+	CLAUDE_ARGS=()
+	parse_args --cdc-publish 3000 -c
+	[ "${#CLAUDE_ARGS[@]}" -eq 1 ]
+	[ "${CLAUDE_ARGS[0]}" = "-c" ]
+}


### PR DESCRIPTION
## Summary

- Add repeatable `--cdc-publish <spec>` wrapper flag that runs `sbx ports <name> --publish <spec>` between sandbox create and claude attach. Spec syntax pass-through to `sbx ports` (`[[HOST_IP:]HOST_PORT:]SANDBOX_PORT[/PROTOCOL]`).
- Per-session cleanup: cdc captures sbx's resolved binding (`Published 127.0.0.1:49153 -> 8000/tcp`) at publish time and uses the canonical `HOST_IP:HOST_PORT:SANDBOX_PORT/PROTO` form for unpublish — so ephemeral host ports clean up correctly. Trap on INT/TERM extends the same cleanup.
- Print resolved bindings (`cdc: published http://127.0.0.1:PORT -> sandbox:PORT`) to stderr so the user discovers ephemeral host ports without running `sbx ports` manually.
- Reject `--cdc-no-sandbox --cdc-publish` at parse-time.
- `--cdc-dry-run` shows a `PUBLISH (would run after create):` block listing planned `sbx ports` invocations without executing anything.
- README gets a new "Viewing a sandbox-hosted service" section + flag-table row + common-invocation example, including the critical "bind 0.0.0.0 inside the sandbox" note.

Closes #39.

## Test plan

- [x] `bats tests/` — 35/35 unit + integration tests pass (parser, helpers, dry-run, run_sandbox wiring, trap, partial-publish failure)
- [x] `shellcheck bin/cdc` clean
- [x] `shfmt -d bin/cdc` clean
- [x] Live sbx — bare-port spec (`8000`) publishes ephemeral host port, host `curl http://127.0.0.1:<ephemeral>` reaches the sandbox-side `python3 -m http.server`, unpublish leaves "No published ports"
- [x] Live sbx — explicit-port spec (`18000:8000`) and mixed specs (`9000` + `18080:80`) both publish + unpublish cleanly
- [x] `cdc --cdc-publish 3000 --cdc-publish 127.0.0.1:8080:80 --cdc-dry-run` shows the PUBLISH block; `sbx ports` is not invoked
- [x] `cdc --cdc-no-sandbox --cdc-publish 3000` exits non-zero with `cdc: --cdc-publish cannot be combined with --cdc-no-sandbox (no sandbox to publish into)`
- [x] `cdc --cdc-doctor` output unchanged from main (port publishing is per-session, not a preflight concern)
- [ ] **Manual verification recommended before merge:** live `cdc --cdc-publish 8000` followed by Ctrl-C — verify the trap fires `unpublish_ports` and `sbx ports <name>` shows no leaks
- [ ] **Manual verification recommended before merge:** live `cdc --cdc-keep-running --cdc-publish 8000` — verify both sandbox AND port survive the session exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)